### PR TITLE
signing very large tx

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -25,3 +25,11 @@ yymmmdd
               tcls_in_sig_script.sh
 17mar20 svn   tcls_create            prepare multisig: create msig address & redeem script
 17apr02 svn   testcase_tcls*         update all checksums after msig preps before
+17may07 svn   testcase*              changed all files to "tcls_testcase", to avoid confusion
+                                     with "real" test files beginning with "test*"
+17jun02 svn   tcls_create.sh         improved fee output: display desired and proposed fees 
+17jun11 svn   tcls_tx2txt.sh         minor cosmetic change in output display
+17jun16 svn   tcls_sign.sh           remove "cut" and "tr" where possible, cause they allow 
+                                     only for limited string lengths. Especially on BSD types.
+                                     Changed to arrays, similiar like tcls_tx2txt.sh. 
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GITHUB messes with the text and newlines, please view in "raw" mode...
 #######################################
 ### 1. TX_CL_SUITE -  description: ###
 #######################################
-A suite of shell scripts to work with Bitcoin transactions. Primary goal is to analyze a transaction. Display it in plain text, similiar to the Bitcoin core client or "www.blockchain.info" JSON output, just in plain text. Second goal is to create or sign transactions. 
+A suite of shell scripts to work with Bitcoin transactions. Primary goal is to analyze a transaction. Display it in plain text, similiar to the Bitcoin core client or "www.blockchain.info" JSON output, just in plain text. Second goal is to create or sign transactions (and cold storage usage). 
 This suite is based on the previous „trx2txt“ tool, which is now discontinued.
 
 Scripts are written to run on OpenBSD and OSX and Linux systems at the command shell (ksh, bash). OthereExisting tools on the web (Bitcoin CLI tools and others), are written to work only with BASHv4. In this suite, all scripts are coded with the intention, to be (nearly) POSIX compliant. Tested on OpenBSD korn shell, MAC OSX BASHv3 and SuSE Linux BASHv4. 
@@ -138,7 +138,7 @@ d61967f63c7dd183914a4ae452c9f6ad5d462ce3d277798075b107615c1a8a30
 
 
 #####################################
-### file testcases_tcls_tx2txt.sh ###
+### file tcls_testcases_tx2txt.sh ###
 #####################################
 This shell script supports the development process, and verifies the script output(s).
 1.) creates sha256 checksums of the involved source code scripts
@@ -148,7 +148,7 @@ This shell script supports the development process, and verifies the script outp
 
 Most easily it is used like this:
 
-  ./testcases_tcls_tx2txt.sh 
+  ./tcls_testcases_tx2txt.sh 
 
 which runs all tests (time consuming). This can be easily compared on all platforms. When hash is equal on all (UNIX/POSIX type of) platforms, code is ready to be uploaded to GITHUB (or similiar). 
 
@@ -218,18 +218,18 @@ Then we would create the transaction (notice the redeemscripthash at the end):
 --> signs the transaction (n times of an "n of m" msig tx, with the corresponding priv/pub key) 
 
 #####################################
-### file testcases_tcls_create.sh ###
+### file tcls_testcases_create.sh ###
 #####################################
 This shell script supports the development process, and verifies the script output(s).
-It is setup the exactly same way as 'testcases_tcls_tx2txt.sh'. Details up there ...
+It is setup the exactly same way as 'tcls_testcases_tx2txt.sh'. Details up there ...
 Most easily it is used like this:
 
-  ./testcases_tcls_create.sh 
+  ./tcls_testcases_create.sh 
 
 #########################
 ### file tcls_sign.sh ###
 #########################
-Advanced usage! As per above (tcls_create.sh), this is the script that follows logically the creation of an unsigned raw transaction, and signs it (preferably on a cold storage system). 
+Advanced usage! As per above (tcls_create.sh), this is the script that follows logically after the creation of an unsigned raw transaction, and will sign it (preferably on a cold storage system). 
 
 Usage example:
   ./tcls_sign.sh -v <raw_trx> -w <privkey> -p <pubkey>
@@ -241,13 +241,13 @@ Hint: in this version the sign process allows for many inputs, which can also be
 See ./tcls_sign.sh -h for more info.
 
 ###################################
-### file testcases_tcls_sign.sh ###
+### file tcls_testcases_sign.sh ###
 ###################################
 This shell script supports the development process, and verifies the script output(s).
-It is setup the exactly same way as 'testcases_tcls_tx2txt.sh'. Details up there ...
+It is setup the exactly same way as 'tcls_testcases_tx2txt.sh'. Details up there ...
 Most easily it is used like this:
 
-  ./testcases_tcls_create.sh 
+  ./tcls_testcases_create.sh 
 
 ############################
 ### file tcls_key2pem.sh ### 
@@ -257,13 +257,13 @@ This shell script is necessary when the signing process is executed. The signatu
 Hint: this tool is now extended with strict DER checks for the signature (see below 'tcls_strict_sig_verify.sh').
 
 ######################################
-### file testcases_tcls_key2pem.sh ###
+### file tcls_testcases_key2pem.sh ###
 ######################################
 This shell script supports the development process, and verifies the script output(s).
-It is setup the exactly same way as 'testcases_tcls_tx2txt.sh'. Details up there ...
+It is setup the exactly same way as 'tcls_testcases_tx2txt.sh'. Details up there ...
 Most easily it is used like this:
 
-  ./testcases_tcls_key2pem.sh 
+  ./tcls_testcases_key2pem.sh 
 
 ######################################
 ### file tcls_strict_sig_verify.sh ### 
@@ -287,13 +287,14 @@ tcls_create.sh and tcls_key2pem.sh.
 #########################
 README.md                         - this file :-)
 Changelog.txt                     - view changes over the files 
+tcls.conf                         - a global config file for all scripts 
 tcls_in_sig_state_machine.graphml - graphics source file for the state machine
                                     (java based app: "yEd Graph Editor")
 tcls_in_sig_state_machine.png     - the exported png for script sig part
 tcls_out_pk_state_machine.graphml - graphics source file for the state machine
                                     (java based app: "yEd Graph Editor")
 tcls_out_pk_state_machine.png     - the exported png for PUBKEY script
-tcls_todos.txt                    - what needs to be done (in the future)
+todos.txt                         - what needs to be done (in the future)
 
 Documentation files are not included in the hashing with any testcases.
 

--- a/tcls_base58check_enc.sh
+++ b/tcls_base58check_enc.sh
@@ -153,7 +153,7 @@ if [ $QUIET -eq 0 ] ; then
   echo "  "
   echo "using $param"
   echo " "
-  if [ $TESTNET -eq 0 ] ; then
+  if [ $TESTNET -eq 1 ] ; then
     echo "preparing for TESTNET"
   fi
 fi

--- a/tcls_testcases_create.sh
+++ b/tcls_testcases_create.sh
@@ -1,0 +1,838 @@
+#!/bin/sh
+# some testcases for the shell script "tcls_create.sh" 
+#
+# Copyright (c) 2015, 2016 Volker Nowarra 
+# updated regularly with the root shell script
+# 
+# Permission to use, copy, modify, and distribute this software for any 
+# purpose with or without fee is hereby granted, provided that the above 
+# copyright notice and this permission notice appear in all copies. 
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY 
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER 
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE 
+# USE OR PERFORMANCE OF THIS SOFTWARE. 
+# 
+
+typeset -i LOG=0
+logfile=$0.log
+
+create_cmd=tcls_create.sh
+
+chksum_verify() {
+if [ "$1" == "$2" ] ; then
+  echo "ok"
+else
+  echo $1 | tee -a $logfile
+  echo "*************** checksum  mismatch, ref is: ********************" | tee -a $logfile
+  echo $2 | tee -a $logfile
+  echo " " | tee -a $logfile
+fi
+}
+
+to_logfile() {
+  # echo $chksum_ref >> $logfile
+  cat tmp_cfile >> $logfile
+  echo " " >> $logfile
+}
+
+chksum_prep() {
+result=$( $chksum_cmd tmp_cfile | cut -d " " -f 2 )
+chksum_verify "$result" "$chksum_ref" 
+if [ $LOG -eq 1 ] ; then to_logfile ; fi
+}
+
+testcase1() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 1: get the checksums of all necessary files     ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+
+echo "=== TESTCASE 1a: $chksum_cmd tcls_create.sh" | tee -a $logfile
+cp tcls_create.sh tmp_cfile
+chksum_ref="8be77a2366aa8eb1c215dc47a01757661d7a89a62132124391ae19dfedc59d7f" 
+chksum_prep
+
+echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
+cp tcls_key2pem.sh tmp_cfile
+chksum_ref="736af2ceeb382639f271abfe8cde580ebce816b98ae149037a95a2268ba7d893" 
+chksum_prep
+
+echo "=== TESTCASE 1c: $chksum_cmd tcls_verify_bc_address.awk" | tee -a $logfile
+cp tcls_verify_bc_address.awk tmp_cfile
+chksum_ref="c944ff89ff49454ca03b0ea8f3ce8ebbd44e33e8d87ab48ae00ad4d6544099f6" 
+chksum_prep
+
+echo "=== TESTCASE 1d: $chksum_cmd tcls_verify_hexkey.awk" | tee -a $logfile
+cp tcls_verify_hexkey.awk tmp_cfile
+chksum_ref="055b79074a8f33d0aa9aa7634980d29f4e3eb0248a730ea784c7a88e64aa7cfd" 
+chksum_prep " " | tee -a $logfile
+
+echo "   " | tee -a $logfile
+}
+
+testcase2() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 2: -c parameters testing ...                    ===" | tee -a $logfile
+echo "=== spend from: 16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM            ===" >> $logfile
+echo "=== spend to:   1runeksijzfVxyrpiyCY2LCBvYsSiFsCm            ===" >> $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 2a: manually create a simple unsigned, raw trx"      | tee -a $logfile
+echo "./$create_cmd -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="4306ec5d3ccc1292257889721ffe0d3c563d906a40368e9b16faa37bf5778cf2" 
+chksum_prep
+
+echo "=== TESTCASE 2b: -c and -f params - that clashes" | tee -a $logfile
+echo "./$create_cmd -v -c -f 76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -v -c -f 76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="bd3bc223b2e274b0f634aaffc1c6584c330e94ebfd42cc647d153428c1b1186a" 
+chksum_prep
+
+echo "=== TESTCASE 2c: -c and -m params - that clashes" | tee -a $logfile
+echo "./$create_cmd -v -c -m 76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -v -c -m 76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="bd3bc223b2e274b0f634aaffc1c6584c330e94ebfd42cc647d153428c1b1186a" 
+chksum_prep
+
+echo "=== TESTCASE 2d: -c and -t params - that clashes" | tee -a $logfile
+echo "./$create_cmd -v -c -t 76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -v -c -t 76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="bd3bc223b2e274b0f634aaffc1c6584c330e94ebfd42cc647d153428c1b1186a" 
+chksum_prep
+
+echo "=== TESTCASE 2e: same as 2a, with verbose output" | tee -a $logfile
+echo "./$create_cmd -v -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -v -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="f6fccfdd8997dda8304c7a79fe3b4d2d25c0e03d71c73c1dd53db53ce28effe9" 
+chksum_prep
+
+echo "=== TESTCASE 2f: same as 2a, with very verbose output" | tee -a $logfile
+echo "### amount to spend (trx_output, in Satoshis):         99900000 ###" >> $logfile
+echo "### proposed TX-FEE (@ 50 Satoshi/Byte * 319 TX_bytes):   15950 ###" >> $logfile
+echo "./$create_cmd -vv -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -vv -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="0e75fab45b51a94c491e53c1c9c8e29d0c79a4677e5aa9f6720334b517117606" 
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase3() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3: intensive param '-r' testing ...             ===" | tee -a $logfile
+echo "=== spend from: 1MBngSqZbMydscpzSoehjP8kznMaHAzh9y           ===" >> $logfile
+echo "=== spend to:   14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s           ===" >> $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3a: only 1 param ... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be > tmp_cfile
+chksum_ref="c980c484e62cd55b8e242db360b20c48a5e66cc1a7c19004c94c54d1ff2ec308"
+chksum_prep
+
+echo "=== TESTCASE 3b: only 2 params... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 > tmp_cfile
+chksum_ref="c03a11c1be69150245ea756be59298820bad9e2a9a3f41a15a45f29341700626"
+chksum_prep
+
+echo "=== TESTCASE 3c: only 3 params... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac > tmp_cfile
+chksum_ref="c03a11c1be69150245ea756be59298820bad9e2a9a3f41a15a45f29341700626"
+chksum_prep
+
+echo "=== TESTCASE 3d: only 4 params... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac 118307" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac 118307 > tmp_cfile
+chksum_ref="c03a11c1be69150245ea756be59298820bad9e2a9a3f41a15a45f29341700626"
+chksum_prep
+
+echo "=== TESTCASE 3e: all params, but TX_IN is char, not numeric... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be A 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac 118307 14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be A 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac 118307 14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s > tmp_cfile
+chksum_ref="968a532af30367f572bacd5d06f16cdb19f09966c6b14af87630b0f5dd566fa1"
+chksum_prep
+
+echo "=== TESTCASE 3f: all params, but AMOUNT is char, not numeric... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac AMOUNT 14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac AMOUNT 14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s > tmp_cfile
+chksum_ref="6825e38208a876fe8f0c34671d6fe7353be2b9b990bceef72f80dd698610f0df"
+chksum_prep
+
+echo "=== TESTCASE 3g: all params, all correct, should run ok ... " | tee -a $logfile
+echo "$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac 118307 14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s" >> $logfile
+./$create_cmd -c 96534da2f213367a6d589f18d7d6d1689748cd911f8c33a9aee754a80de166be 0 1976a914dd6cce9f255a8cc17bda8ba0373df8e861cb866e88ac 118307 14zWNsgUMmHhYx4suzc2tZD6HieGbkQi5s > tmp_cfile
+chksum_ref="6c3341a2e4e945684d8c95e164a63cb0207f6e84882f066c4f50d1aa745c273e"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase4() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 4: 4a, 4b and 4c not ok, 4d ok                  ===" | tee -a $logfile
+echo "=== spend from: 1CAue7dQ2ASD6Wj9ZUWJABdC2zteiCe5cK           ===" >> $logfile
+echo "=== spend to:   12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM           ===" >> $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 4a: wrong bitcoin adress hash (x at end)"            | tee -a $logfile
+echo "./$create_cmd -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdMx" >> $logfile
+./$create_cmd -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdMx > tmp_cfile
+chksum_ref="28b7b946f9221044c71ec09d3b3c1b16c4fff26f089931a9d568763d1aa9421a" 
+chksum_prep
+
+echo "=== TESTCASE 4b: same as 4a, with verbose output" | tee -a $logfile
+echo "./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdMx" >> $logfile
+./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdMx > tmp_cfile
+chksum_ref="c40ed54979f0629df03ed0343a1533597a95c6094863610a2e5244456f429463" 
+chksum_prep
+
+echo "=== TESTCASE 4c: same as 4a, with very verbose output" | tee -a $logfile
+echo "./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdMx" >> $logfile
+./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdMx > tmp_cfile
+chksum_ref="e64bb0797032e18a9c720086cefa78dbe876b205316209ff347a06edaf9d14ec" 
+chksum_prep
+
+echo "=== TESTCASE 4d: and now with correct bitcoin adress hash" | tee -a $logfile
+echo "### amount to spend (trx_output, in Satoshis):           100000 ###" >> $logfile 
+echo "### proposed TX-FEE (@ 50 Satoshi/Byte * 321 TX_bytes):   16050 ###" >> $logfile
+echo "./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 100000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="507f1e00bcf4fccd78466842a21f6e8f2ffeffcfa0de8ffbe9b38489336ceaac" 
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase5() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 5: Addresses with leading 1s ...                ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 5a: 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM " | tee -a $logfile
+echo "./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="50bcb094a96df626bad9917350578f4b19afebb506814d9c603351094be53a06"
+chksum_prep
+
+echo "=== TESTCASE 5b: 112ZbzFcSpcCoY2EfPNmgxFmv4tVuLSoB4 " | tee -a $logfile
+echo "./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 112ZbzFcSpcCoY2EfPNmgxFmv4tVuLSoB4" >> $logfile
+./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 112ZbzFcSpcCoY2EfPNmgxFmv4tVuLSoB4 > tmp_cfile
+chksum_ref="4aac7ca086ff6fbef81a6f92ce960af6396f15bf522027b8db3eb643d29941bc"
+chksum_prep
+
+echo "=== TESTCASE 5c: 1111DAYXhoxZx2tsRnzimfozo783x1yC2" | tee -a $logfile
+echo "./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111DAYXhoxZx2tsRnzimfozo783x1yC2 " >> $logfile
+./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111DAYXhoxZx2tsRnzimfozo783x1yC2 > tmp_cfile
+chksum_ref="39ba2900c21dc80808d65fcbc23dee497ab59cd19e0a26a0132a663ae830fd21"
+chksum_prep
+
+echo "=== TESTCASE 5d: 1111VHuXEzHaRCgXbVwojtaP7Co3QABb" | tee -a $logfile
+echo "./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111VHuXEzHaRCgXbVwojtaP7Co3QABb " >> $logfile
+./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111VHuXEzHaRCgXbVwojtaP7Co3QABb > tmp_cfile
+chksum_ref="7e08fafeebf112d5036f9f210ce3176718c8764f5692f9f4b8bf8d9a6f4ea81e"
+chksum_prep
+
+echo "=== TESTCASE 5e: 1111KiuFyqUXJFji8KQnoHC5Rtqa5d5e" | tee -a $logfile
+echo "./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111KiuFyqUXJFji8KQnoHC5Rtqa5d5e " >> $logfile
+./$create_cmd -v -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111KiuFyqUXJFji8KQnoHC5Rtqa5d5e > tmp_cfile
+echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u >> tmp_cfile
+chksum_ref="a439f619e761ffde251a889fdbebf1edda011d23dc695abb9871bd30c7472dba"
+chksum_prep
+
+echo "=== TESTCASE 5f: 1111LexYVhKvaQY69Paj774F9gnjhDrr " | tee -a $logfile
+echo "./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111LexYVhKvaQY69Paj774F9gnjhDrr" >> $logfile
+./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111LexYVhKvaQY69Paj774F9gnjhDrr > tmp_cfile
+echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u >> tmp_cfile
+chksum_ref="9909158628ba74bc965a43d9127d7384e95d068e281f4570f49473db1fc6522d"
+chksum_prep
+
+echo "=== TESTCASE 5g: 111113CRATaaDmCcWzokzTGhM886kj2bs" | tee -a $logfile
+echo "./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 111113CRATaaDmCcWzokzTGhM886kj2bs " >> $logfile
+./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 111113CRATaaDmCcWzokzTGhM886kj2bs > tmp_cfile
+echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u >> tmp_cfile
+chksum_ref="5cd1af58fd42efd8eec9fb3a5b0ac3530dd43cb829cac40972aabc3b76ad3495"
+chksum_prep
+
+echo "=== TESTCASE 5h: 1111111111111111111114oLvT2 " | tee -a $logfile
+echo "./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111111111111111111114oLvT2 " >> $logfile
+./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 110000 1111111111111111111114oLvT2 > tmp_cfile
+echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u >> tmp_cfile
+chksum_ref="4470f449b78871d7612d8a3c03d8d478cf6b0ab0242305ce9b78cd303c34757a" 
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase6() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 6: usage of param '-t'                          ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 6a: read a transaction from the network"             | tee -a $logfile
+echo "=== when reading from network (-t), then the txfees must change." >> $logfile
+echo "=== fee value from bitcoinfees.21.co is different than program  " >> $logfile
+echo "=== defaults (50 Satoshi/byte), e.g.:"                            >> $logfile
+echo "## amount of trx input(s) (in Satoshis):              1100000 ##" >> $logfile
+echo "## amount to spend (trx_output, in Satoshis):         1099999 ##" >> $logfile
+echo "## proposed TX-FEE (@ 140 Satoshi/Byte * 319 TX_bytes): 44660 ##" >> $logfile
+echo "##                  ^^^^^^^^^^^^^^^^^ this must have changed!   " >> $logfile
+echo "## and last line should be:"                                      >> $logfile
+echo "## ... ERROR: input insufficient, to cover trx fees, ..."         >> $logfile
+
+echo "./$create_cmd -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 1099999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 1099999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="0000000000000000000000000000000000000000000000000000000000000000" 
+head -n8 tmp_cfile > tmp_cfile1
+grep "proposed TX-FEE (@ 50 Satoshi/Byte" tmp_cfile
+if [ $? -eq 1 ] ; then 
+  tail -n 2 tmp_cfile | grep "ERROR: input insufficient" > /dev/null
+  if [ $? -eq 0 ] ; then 
+    echo "   ### good, Satoshi/Bytes value is different," >> $logfile
+    echo "   ### and we have the error at the end"        >> $logfile
+    chksum_ref="b0f3f3a5282a2ea18b00c020494afeb3a34ddf67d6df7a0cd4a64b05b59efcd5"
+  fi
+fi
+mv tmp_cfile1 tmp_cfile
+chksum_prep
+
+echo "=== TESTCASE 6b: nearly same as 6a, different value" | tee -a $logfile
+echo "===   from: 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM"      >> $logfile
+echo "===   to:   12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM"      >> $logfile
+echo "./$create_cmd -v -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 1099999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -v -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 1099999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile1
+head -n32 tmp_cfile1 > tmp_cfile
+echo "## need to remove last three lines, cause parameter "     >> $logfile
+echo "## for txfee can change on network. Last line should be:" >> $logfile
+echo "## ... ERROR: input insufficient, to cover trx fees, ..." >> $logfile
+chksum_ref="9f2c963d825c87473f11587d19766d9e7266c1840639720665705da9d4c4530c" 
+chksum_prep
+
+echo "=== TESTCASE 6c: same as 6b, with parameter for TRXFEE" | tee -a $logfile
+echo "===   proposed TX-FEE (@ 77 Satoshi/Byte * 319 tx_bytes): 24563"  >> $logfile
+echo "===   *** possible value to return address:                 437"  >> $logfile
+echo "===   *** without return address, txfee will be:          25000"  >> $logfile
+echo "./$create_cmd -v -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 1075000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 77" >> $logfile
+./$create_cmd -v -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 1075000 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 77 > tmp_cfile
+chksum_ref="5168db68ffd262998daa8b7d5a6d803cb2985751fdd78692987fec1dd154a0cb" 
+chksum_prep
+
+echo "=== TESTCASE 6d: same as 6b, with parameter for a return address" | tee -a $logfile
+echo "===   proposed TX-FEE (@ 50 Satoshi/Byte * 387 tx_bytes): 19350 " >> $logfile
+echo "===   value to return address:                             2873 " >> $logfile
+echo "===   return address: 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm         " >> $logfile
+echo "./$create_cmd -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 999999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 50 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 999999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 50 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="ccea1cf04c4a482a13ee3deb71d6e1e39dc7a366b1728a35d1abf4c403086fd5" 
+chksum_prep
+
+echo "=== TESTCASE 6e: same as 6d, VERBOSE output" | tee -a $logfile
+echo "=== proposed TX-FEE (@ 50 Satoshi/Byte * 387 TX_bytes):  19350" >> $logfile
+echo "=== value to return address:                             80651" >> $logfile
+echo "./$create_cmd -v -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 999999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 50 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -v -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 999999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 50 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="660b99d1fb18804f0ad368866138a40dfa1cd6dffe299b8329f68580442a4f31" 
+chksum_prep
+
+echo "=== TESTCASE 6f: same as 6d, VERY VERBOSE output" | tee -a $logfile
+echo "=== proposed TX-FEE (@ 50 Satoshi/Byte * 387 TX_bytes):  19350" >> $logfile
+echo "=== value to return address:                             80651" >> $logfile
+echo "./$create_cmd -vv -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 999999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 50 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -vv -t 1de803fe2e3795f7b92d5acc113d3e452939ec003ce83309386ce4213c6812bc 0 999999 12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM 50 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="14737c3b0bd2e854db8baa16b71a5e89d410144b9ec0409b487c5becfddb611e" 
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase7() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 7: several trx with wrong parameters:           ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 7a: insufficient input" | tee -a $logfile
+echo "===              amount of trx input(s) (in Satoshis):    59372 " >> $logfile
+echo "===              desired amount to spend (in Satoshis):   70000 " >> $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19235" > tmp_3inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16197" >> tmp_3inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23940" >> tmp_3inputs.txt
+echo "./$create_cmd -v -f tmp_3inputs.txt 70000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+./$create_cmd -v -f tmp_3inputs.txt 70000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM > tmp_cfile
+chksum_ref="e8837815cf2f44e47f4f57ba9288c608825a90b8ed0adedc9b302946e9573c72" 
+chksum_prep
+
+echo "=== TESTCASE 7b: wrong output address (x at the end)" | tee -a $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19235" > tmp_3inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16197" >> tmp_3inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23940" >> tmp_3inputs.txt
+echo "./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcx" >> $logfile
+./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcx > tmp_cfile
+chksum_ref="2a56205032858fe92365032175fb04dd23c4150f5742a5d2512b590b3e443c64" 
+chksum_prep
+
+echo "=== TESTCASE 7c: wrong length of trx hash (63 chars)" | tee -a $logfile
+echo "4fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 39235" > tmp_3inputs.txt
+echo "3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16197" >> tmp_3inputs.txt
+echo "74cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23940" >> tmp_3inputs.txt
+echo "./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM > tmp_cfile
+chksum_ref="5ab2b820286469f40a4d61039d8060662eec04af4b18629304350db11e7c832a" 
+chksum_prep
+
+echo "=== TESTCASE 7d: insufficient trx fee" | tee -a $logfile
+echo "=== proposed TX-FEE (@ 50 Satoshi/Byte * 763 tx_bytes):    38150" >> $logfile
+echo "=== Achieving negative value with this txfee:               -900" >> $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 39255" > tmp_3inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19999" >> tmp_3inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 27996" >> tmp_3inputs.txt
+echo "./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM 50" >> $logfile
+./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM 50 > tmp_cfile
+chksum_ref="805e5cc495c567838b707be3f999a751e47c40f73f9ae6f0a81cee3d833debc3" 
+chksum_prep
+
+echo "=== TESTCASE 7e: wrong return address (x at the end)" | tee -a $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 39235" > tmp_3inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 26197" >> tmp_3inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23940" >> tmp_3inputs.txt
+echo "./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM 50 16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvx" >> $logfile
+./$create_cmd -v -f tmp_3inputs.txt 50000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM 50 16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvx > tmp_cfile
+chksum_ref="e15f11c9940fbfe6f54edf26bf8bf01017aa096e483b487a5835c9e73f9ff073"
+chksum_prep
+
+echo "=== TESTCASE 7f: a spend from 1JmPRD_unspent.txt     " | tee -a $logfile
+echo "=== 4 inputs from: 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+echo "===            to: 13GnHB51piDBf1avocPL7tSKLugK4F7U2B" >> $logfile
+echo "=== proposed TX-FEE (@ 32 Satoshi/Byte * 985 tx_bytes):    31520" >> $logfile
+echo "=== *** possible value to return address:                    480" >> $logfile
+echo "=== *** without return address, txfee will be:             32000" >> $logfile
+echo "48d2c9c76dc282eb7075a0fce543b9d615c0c2d5b78b41603c2d6cf46e2e77b0 1 76a914c2df275d78e506e17691fd6f0c63c43d15c897fc88ac 120000" > tmp_4inputs.txt
+echo "811848214a52c823f53eaaa302eaddb7dd2b03874174c9202d291ac35868fb74 1 76a914c2df275d78e506e17691fd6f0c63c43d15c897fc88ac 500000" >> tmp_4inputs.txt
+echo "bb745b565d23c2041022392469114cbd94d29d941e1c6860c609b5ed6ee321cc 0 76a914c2df275d78e506e17691fd6f0c63c43d15c897fc88ac 113000" >> tmp_4inputs.txt
+echo "e84959a7148737df867d6c83f3683abeb977c297729ccbd609d54ee0879491ea 0 76a914c2df275d78e506e17691fd6f0c63c43d15c897fc88ac 120000" >> tmp_4inputs.txt
+echo "./$create_cmd -vv -f tmp_4inputs.txt 821000 13GnHB51piDBf1avocPL7tSKLugK4F7U2B 32" >> $logfile
+./$create_cmd -vv -f tmp_4inputs.txt 821000 13GnHB51piDBf1avocPL7tSKLugK4F7U2B 32 > tmp_cfile
+chksum_ref="456dc2d75a500b630a774f36ffe4108dac58bf879a9eacb0f27d934075923044"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase8() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 8: some multi input trx with 3, 5 and 20 inputs ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 8a: 3 inputs to a trx"                               | tee -a $logfile
+echo "=== proposed TX-FEE (@ 25 Satoshi/Byte * 1207 TX_bytes):   38150" >> $logfile
+echo "=== *** possible value to return address:                      2" >> $logfile
+echo "=== *** without return address, txfee will be:             38152" >> $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 49265" > tmp_3inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 18887" >> tmp_3inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 50000" >> tmp_3inputs.txt
+echo "./$create_cmd -vv -f tmp_3inputs.txt 80000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+./$create_cmd -vv -f tmp_3inputs.txt 80000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM > tmp_cfile
+chksum_ref="196f44365abea755565119bf93875bb644cb5f67c70ebfaee4f6c471246110c7" 
+chksum_prep
+
+echo "=== TESTCASE 8b: 5 inputs to a trx" | tee -a $logfile
+echo "=== proposed TX-FEE (@ 50 Satoshi/Byte * 1207 TX_bytes):   30175" >> $logfile
+echo "=== *** possible value to return address:                      2" >> $logfile
+echo "=== *** without return address, txfee will be:             30177" >> $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 39235" >> tmp_5inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 48197" >> tmp_5inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 26940" >> tmp_5inputs.txt
+echo "722a2ad4daa66382abe4c54676cfe1299ac52a239b4b79b6c6f66e5c5fefe32c 475 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 6886" >> tmp_5inputs.txt
+echo "0d87c9c4146452dd8f97f646b52a9dda5a6645d068aca5f1a2a214d37507c5b5 989 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19099" >> tmp_5inputs.txt
+echo "./$create_cmd -v -f tmp_5inputs.txt 110180 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+./$create_cmd -v -f tmp_5inputs.txt 110180 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM > tmp_cfile
+chksum_ref="a193916eb612a40583f0ec491aeeb7950b964f163cebab5617e9d7ec30d4ec0a"
+chksum_prep
+
+echo "=== TESTCASE 8c: 23 inputs to a trx" | tee -a $logfile
+echo "===  from: 1FyJw3R7cs9TrSXPhh1FnnGmgTMdptPSE7  " >> $logfile
+echo "===    to: 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM  " >> $logfile
+echo "=== proposed TX-FEE (@ 25 Satoshi/Byte * 5203 TX_bytes):  130075" >> $logfile
+echo "=== *** possible value to return address:                      1" >> $logfile
+echo "=== *** without return address, txfee will be:            130076" >> $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 119235" >> tmp_23inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16197" >> tmp_23inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23940" >> tmp_23inputs.txt
+echo "722a2ad4daa66382abe4c54676cfe1299ac52a239b4b79b6c6f66e5c5fefe32c 475 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 6816" >> tmp_23inputs.txt
+echo "0d87c9c4146452dd8f97f646b52a9dda5a6645d068aca5f1a2a214d37507c5b5 989 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19099" >> tmp_23inputs.txt
+echo "e90fb95d397c965f4bb7f25e3efc9554aa73b0692b114de5375955fdc7b0308d 771 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 42128" >> tmp_23inputs.txt
+echo "c1e162bdd8b2c2e0c68e144b116686e230a1ac2b1cae886fedb8eae4a0b9b4d5 1243 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 11186" >> tmp_23inputs.txt
+echo "1dfd30d0ef6c710baff303dc30e056233a9d18e06043471fbf2f364ce203a16d 1063 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15511" >> tmp_23inputs.txt
+echo "a31870644f16e0751fbb8df753e7076755366fe711e9b18ab9ac7696ed47419d 544 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 2730" >> tmp_23inputs.txt
+echo "9bfe95cd84bc1adad42d2eb76e605ec587f3308d969e582c7fd00d7d00c0bc93 831 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16532" >> tmp_23inputs.txt
+echo "8b7bd94fa11297f59fdf82923f5e548aa31d9e2a73a2aadb0865dccf3cde6b10 532 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 18588" >> tmp_23inputs.txt
+echo "a96ded3a7af074535e58f6ce9b5fadcc9cd4e5a28672c97389b1094c1b8cdfe6 1114 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 22115" >> tmp_23inputs.txt
+echo "aece8ad19c4c88906c9bee181a4c021828a5eaf4f5001435989d07a2fe1acaac 513 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 6640" >> tmp_23inputs.txt
+echo "fd0faeffc7105159e1ac21f052dd84d2f35e07bf3f897562cdf1d6b914453e1c 1247 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 24986" >> tmp_23inputs.txt
+echo "5c31fb9784dc34004664c19a77dac96f08375942fcd058769f46df3fa45420a7 466 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 4285" >> tmp_23inputs.txt
+echo "d6dd6411750c74de83babc3cd2188c692c8bab812a50a3ae9ca996f269fdf7c0 520 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 8207" >> tmp_23inputs.txt
+echo "7821677c830cad4205d463f781bd068a6bb92382faf21b1a6c7975548a0fc9f5 713 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 5697" >> tmp_23inputs.txt
+echo "4aa7a3ad6a56d6afee991ec67ae9b75d7264c484be8dc44fbe32ca200c4fe58f 468 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 29790" >> tmp_23inputs.txt
+echo "09b1f67adcc5acb4ec3acd025c6c1dab79efd010b2208a097aa6eefd4fc3be95 508 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 105693" >> tmp_23inputs.txt
+echo "c19479c4147c359b9c48fcaeabee5ac77cc7b6ca68f86803d48b051f84804a2f 1174 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 27499" >> tmp_23inputs.txt
+echo "64d0d67f0df58f8001b555b3fd02863e3e5a9e1bd69976fd722ee579426ec1f6 592 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 27972" >> tmp_23inputs.txt
+echo "8ff75867f8ef344d6ce97053296d21c79ac85b6431aebb5f6abd2eba628b9094 573 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19729" >> tmp_23inputs.txt
+echo "2aaaaaaaaaaaaaad6ce97053296d21c79ac85b6431aebb5f6abd2eba628b9094 111 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 5501" >> tmp_23inputs.txt
+echo "./$create_cmd -f tmp_23inputs.txt 450000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+./$create_cmd -f tmp_23inputs.txt 450000 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM > tmp_cfile
+chksum_ref="b712cc24f4e22deb7193df0c319eb107fc9eb79fdd86cd22d9e64ddc2cd7023a" 
+chksum_prep
+
+
+echo "=== TESTCASE 8d: 53 inputs to a trx" | tee -a $logfile
+echo "===  from: 1FyJw3R7cs9TrSXPhh1FnnGmgTMdptPSE7  " >> $logfile
+echo "===    to: 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM  " >> $logfile
+echo "=== proposed TX-FEE (@ 16 Satoshi/Byte * 12085 TX_bytes): 193360" >> $logfile
+echo "=== *** possible value to return address:                      5" >> $logfile
+echo "=== *** without return address, txfee will be:            193365" >> $logfile
+echo "94fae0ac28792796063f23f4a4ba4f977a9599d1579c5aae7ce6dda4f8a6b1bb 1044 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 119235" >> tmp_53inputs.txt
+echo "a3e719b12275357b15fc5decd9088a0964fe860d49f026f2152e71f681ac3fa4 1073 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16197" >> tmp_53inputs.txt
+echo "874cd4c4e1683c43a98a9daa0926bea37c10616f165ac35481e8181bfd449c65 480 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23940" >> tmp_53inputs.txt
+echo "722a2ad4daa66382abe4c54676cfe1299ac52a239b4b79b6c6f66e5c5fefe32c 475 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 6816" >> tmp_53inputs.txt
+echo "0d87c9c4146452dd8f97f646b52a9dda5a6645d068aca5f1a2a214d37507c5b5 989 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19099" >> tmp_53inputs.txt
+echo "e90fb95d397c965f4bb7f25e3efc9554aa73b0692b114de5375955fdc7b0308d 771 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 42128" >> tmp_53inputs.txt
+echo "c1e162bdd8b2c2e0c68e144b116686e230a1ac2b1cae886fedb8eae4a0b9b4d5 1243 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 11186" >> tmp_53inputs.txt
+echo "1dfd30d0ef6c710baff303dc30e056233a9d18e06043471fbf2f364ce203a16d 1063 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15511" >> tmp_53inputs.txt
+echo "a31870644f16e0751fbb8df753e7076755366fe711e9b18ab9ac7696ed47419d 544 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 2730" >> tmp_53inputs.txt
+echo "9bfe95cd84bc1adad42d2eb76e605ec587f3308d969e582c7fd00d7d00c0bc93 831 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16532" >> tmp_53inputs.txt
+echo "8b7bd94fa11297f59fdf82923f5e548aa31d9e2a73a2aadb0865dccf3cde6b10 532 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 18588" >> tmp_53inputs.txt
+echo "a96ded3a7af074535e58f6ce9b5fadcc9cd4e5a28672c97389b1094c1b8cdfe6 1114 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 22115" >> tmp_53inputs.txt
+echo "aece8ad19c4c88906c9bee181a4c021828a5eaf4f5001435989d07a2fe1acaac 513 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 6640" >> tmp_53inputs.txt
+echo "fd0faeffc7105159e1ac21f052dd84d2f35e07bf3f897562cdf1d6b914453e1c 1247 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 24986" >> tmp_53inputs.txt
+echo "5c31fb9784dc34004664c19a77dac96f08375942fcd058769f46df3fa45420a7 466 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 4285" >> tmp_53inputs.txt
+echo "d6dd6411750c74de83babc3cd2188c692c8bab812a50a3ae9ca996f269fdf7c0 520 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 8207" >> tmp_53inputs.txt
+echo "7821677c830cad4205d463f781bd068a6bb92382faf21b1a6c7975548a0fc9f5 713 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 5697" >> tmp_53inputs.txt
+echo "4aa7a3ad6a56d6afee991ec67ae9b75d7264c484be8dc44fbe32ca200c4fe58f 468 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 29790" >> tmp_53inputs.txt
+echo "09b1f67adcc5acb4ec3acd025c6c1dab79efd010b2208a097aa6eefd4fc3be95 508 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 105693" >> tmp_53inputs.txt
+echo "c19479c4147c359b9c48fcaeabee5ac77cc7b6ca68f86803d48b051f84804a2f 1174 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 27499" >> tmp_53inputs.txt
+echo "64d0d67f0df58f8001b555b3fd02863e3e5a9e1bd69976fd722ee579426ec1f6 592 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 27972" >> tmp_53inputs.txt
+echo "8ff75867f8ef344d6ce97053296d21c79ac85b6431aebb5f6abd2eba628b9094 573 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 19729" >> tmp_53inputs.txt
+echo "7514be159a9ea2e3c8008af8004b1e83c7680ca38032c487a8e81231c3af4142 476 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 4264" >> tmp_53inputs.txt
+echo "1e0126bd3c400347aee4b05893e6d8fd47d2baa106b5426c433482cd61143d49 709 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 41415" >> tmp_53inputs.txt
+echo "53dd658c40fbe6adac20064936f2dbc2d705e6e1ab59a123246373b3285d2a79 623 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 21704" >> tmp_53inputs.txt
+echo "2541df7a81b1906dc3f9adb64bc2beb4430282d545fa8606d34e89c09264c2d6 698 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 5210" >> tmp_53inputs.txt
+echo "edbcab3fd7782568fd4b17fc61bcd546dbb31cb1b035f9092bd3df6f8a2bdfd3 718 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 3398" >> tmp_53inputs.txt
+echo "9a4bfa0913dd35b3fe8798e611370d5fc2bdfd2d4015fcb9321295074766ebfd 849 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15521" >> tmp_53inputs.txt
+echo "38647492766f7a0c6c9dce81a5f3f4a11a80db55efa1720025b8314fb2dc8d6c 1213 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 14191" >> tmp_53inputs.txt
+echo "38148eb25e5e06d5f033671cbfa9b2e3ca86edb18d92707207583b3791b7f489 1257 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 14425" >> tmp_53inputs.txt
+echo "8d0b534b240a2fcb9164bab5009c9a58cca408ef62511e5f0a8d6782699fa1bd 602 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 23361" >> tmp_53inputs.txt
+echo "d12c3a79f3f6bbe6d57a148e5d6961d3ae10791f970596e2a40d747461292ab7 439 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 4365" >> tmp_53inputs.txt
+echo "9dcadf0f65abd725bde93491e10d47b4b80ebeb4ebf2e9481791f7d903414cfe 268 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 100483" >> tmp_53inputs.txt
+echo "2048cdb7230ee02db29d9b02e06ee7dda51a64818ed6714c6b1e1d35cb20d66a 404 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 28144" >> tmp_53inputs.txt
+echo "09c9297d076667cc45d3241b19e7bdfad3d5a8878749a80f0f968093e20f22d9 571 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 24716" >> tmp_53inputs.txt
+echo "5f4012583ea210db6e201da20777240b32b21086105f65c117a7afe0f43ef1b1 1153 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15844" >> tmp_53inputs.txt
+echo "aa41f537c086b7a8286601b89810900985d9f3aea17d27c1db4c5dfdae4721a6 733 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 3033" >> tmp_53inputs.txt
+echo "9fb7bd72bad3b82097bb65243e01e5ab45ec549c4b155b9bdd9ffe8ad7887c48 406 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15580" >> tmp_53inputs.txt
+echo "b14b007c4a384fcf4073e4f05edb1cc7074b3f0160009107c265047e39c6da5b 792 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16708" >> tmp_53inputs.txt
+echo "3ca28bbacf76cb4ef002b2141381cd450a9c6bea01f86b31c681928fc1389517 406 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 11580" >> tmp_53inputs.txt
+echo "e79d423f32ff7786fd89ad68f711fdadc68e3efc0727395e197b7a5260365b6b 709 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 40822" >> tmp_53inputs.txt
+echo "194518262a5280d4352d1553f64e343caeb2e602c279fd9cf594ccb523eb87bd 1058 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15240" >> tmp_53inputs.txt
+echo "f275ba9db842a034fd08a51dca8042e45056fde0981674bf43648e4b1f1cb534 676 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 40003" >> tmp_53inputs.txt
+echo "d25fed56d5cf68a31150b451ad3bc74e43ae8623bd138af1fa949e166aaa0ca7 1160 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 11916" >> tmp_53inputs.txt
+echo "4e0b10d608c534e03b2f499ecc07d958567100c1bb082b7d54cd16de389b69fe 737 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 37593" >> tmp_53inputs.txt
+echo "7f9f29d762a575405dc79f820607ef5b306bd67051d9900e076044a0ed799f0b 1243 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 11332" >> tmp_53inputs.txt
+echo "f47db0ec4fb39256eab313e77b9ee5ec3561fba4ae2557da0b8f96c0470ab48a 427 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 3837" >> tmp_53inputs.txt
+echo "8d718b1f1982e8fd40fe6431b2aa91c8754983005991024a9e6681953930a444 417 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 3286" >> tmp_53inputs.txt
+echo "fde20ff6f219e203ca567c6ac60c16ae4b35301cbb7aa388715d300226665ed3 423 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 22730" >> tmp_53inputs.txt
+echo "02cbaeda78066dc12d273caef84c74dd54f732d489691cf1d213c5b34719cca3 614 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 5191" >> tmp_53inputs.txt
+echo "835a00e11146d0130489f7be116da9e836b3adbfa5b375b50dba57785b13cbd5 591 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 24138" >> tmp_53inputs.txt
+echo "fbf1d6df19021c6dddad3f35d19b6da3b485fbaa84d9ca77f9580ebdb232eea8 1166 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 15293" >> tmp_53inputs.txt
+echo "f46d6ad7b7bef16e65aecae962d96b731a2b638eeb9835382e8bfad8b6224b93 424 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 16020" >> tmp_53inputs.txt
+echo "a3b13803b6bce97cfb5d37008d13e686fc5c8ffeca0078e2f49f9da2165576a6 1250 76A914A438060482FCD835754EA4518C70CC2085AF48FA88AC 25287" >> tmp_53inputs.txt
+echo "./$create_cmd -f tmp_53inputs.txt 1017840 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM" >> $logfile
+./$create_cmd -f tmp_53inputs.txt 1017840 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM > tmp_cfile
+chksum_ref="655b28d1a7b9c372901d1196d6e966e983460fed854c8d851bf4c30d5e8b1204" 
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase9() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 9: -m parameters testing, for multisig preps    ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 9a: msig, 2of3, only 1 address"                      | tee -a $logfile
+echo "./$create_cmd -m 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm" >> $logfile
+./$create_cmd -m 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm > tmp_cfile
+chksum_ref="d620c60622281751fcdaf04626979282391c6334ef561c60304301abbf883d20"
+chksum_prep
+
+echo "=== TESTCASE 9b: msig, 2of3, only 2 addresses" | tee -a $logfile 
+echo "./$create_cmd -m 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM" >> $logfile 
+./$create_cmd -m 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM > tmp_cfile
+chksum_ref="da05d426f21e377f44ef369e2d40ef94aec44921d17e94358800e54a93ff5085"
+chksum_prep
+
+echo "=== TESTCASE 9c: msig, 2of16, invalid, max=15" | tee -a $logfile
+echo "./$create_cmd -m 2 16 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -m 2 16 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="5b677a956e465008b297f1b490df5fe033de9749674fba11a4ed99445c6963ee"
+chksum_prep
+
+echo "=== TESTCASE 9d: msig, 3of2, invalid, 3of2 does not work :-)" | tee -a $logfile
+echo "./$create_cmd -v -m 3 2 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -v -m 3 2 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="5fdd9da7e6fb314c8a6cf6eb411d318c5f33cdd643593feabd47056278f1a643"
+chksum_prep
+
+echo "=== TESTCASE 9e: -m and -f params - that clashes!" | tee -a $logfile
+echo "./$create_cmd -v -m -f 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -v -m -f 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="62710f06f1629cc01a7c5fe1886672bd1540d92450d58f7d4cb5ba2db55f22db"
+chksum_prep
+
+echo "=== TESTCASE 9f: -m and -c params - that clashes!" | tee -a $logfile
+echo "./$create_cmd -v -m -c 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -v -m -c 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="62710f06f1629cc01a7c5fe1886672bd1540d92450d58f7d4cb5ba2db55f22db"
+chksum_prep
+
+echo "=== TESTCASE 9g: -m and -t params - that clashes!" | tee -a $logfile
+echo "./$create_cmd -v -m -t 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -v -m -t 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="62710f06f1629cc01a7c5fe1886672bd1540d92450d58f7d4cb5ba2db55f22db"
+chksum_prep
+
+echo "=== TESTCASE 9h: msig, 2of3, but wrong bitcoin pubkeys" | tee -a $logfile
+echo "./$create_cmd -m 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM" >> $logfile
+./$create_cmd -m 2 3 1runeksijzfVxyrpiyCY2LCBvYsSiFsCm,16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM,12GTF5ARSrqJ2kZd4C9XyGPesoVgP5qCdM > tmp_cfile
+chksum_ref="a153effcf31d88179ba8c85ebb4af9e99637f783e823086e852d8741e5cfa36e"
+chksum_prep
+
+echo "=== TESTCASE 9i: msig 2of3, uncompressed pubkeys, ok ..."          | tee -a $logfile
+echo "    https://gist.githubusercontent.com/gavinandresen/3966071/raw/" >> $logfile
+echo "    1f6cfa4208bc82ee5039876b4f065a705ce64df7/TwoOfThree.sh"        >> $logfile
+echo "./$create_cmd -v -m 2 3 0491bba2510912a5bd37da1fb5b1673010e43d2c6d812c514e91bfa9f2eb129e1c183329db55bd868e209aac2fbc02cb33d98fe74bf23f0c235d6126b1d8334f86,04865c40293a680cb9c020e7b1e106d8c1916d3cef99aa431a56d253e69256dac09ef122b1a986818a7cb624532f062c1d1f8722084861c5c3291ccffef4ec6874,048d2455d2403e08708fc1f556002f1b6cd83f992d085097f9974ab08a28838f07896fbab08f39495e15fa6fad6edbfb1e754e35fa1c7844c41f322a1863d46213" >> $logfile
+./$create_cmd -v -m 2 3 0491bba2510912a5bd37da1fb5b1673010e43d2c6d812c514e91bfa9f2eb129e1c183329db55bd868e209aac2fbc02cb33d98fe74bf23f0c235d6126b1d8334f86,04865c40293a680cb9c020e7b1e106d8c1916d3cef99aa431a56d253e69256dac09ef122b1a986818a7cb624532f062c1d1f8722084861c5c3291ccffef4ec6874,048d2455d2403e08708fc1f556002f1b6cd83f992d085097f9974ab08a28838f07896fbab08f39495e15fa6fad6edbfb1e754e35fa1c7844c41f322a1863d46213 > tmp_cfile
+chksum_ref="85cd6861acd8ed8f7a14d399891e10dc04171093e59751d81f5ca9e9a989b87a"
+chksum_prep
+
+echo "=== TESTCASE 9j: msig 2of3, uncompressed pubkeys, ok ..." | tee -a $logfile
+echo "./$create_cmd -v -m 2 3 04a882d414e478039cd5b52a92ffb13dd5e6bd4515497439dffd691a0f12af9575fa349b5694ed3155b136f09e63975a1700c9f4d4df849323dac06cf3bd6458cd,046ce31db9bdd543e72fe3039a1f1c047dab87037c36a669ff90e28da1848f640de68c2fe913d363a51154a0c62d7adea1b822d05035077418267b1a1379790187,0411ffd36c70776538d079fbae117dc38effafb33304af83ce4894589747aee1ef992f63280567f52f5ba870678b4ab4ff6c8ea600bd217870a8b4f1f09f3a8e83" >> $logfile
+./$create_cmd -v -m 2 3 04a882d414e478039cd5b52a92ffb13dd5e6bd4515497439dffd691a0f12af9575fa349b5694ed3155b136f09e63975a1700c9f4d4df849323dac06cf3bd6458cd,046ce31db9bdd543e72fe3039a1f1c047dab87037c36a669ff90e28da1848f640de68c2fe913d363a51154a0c62d7adea1b822d05035077418267b1a1379790187,0411ffd36c70776538d079fbae117dc38effafb33304af83ce4894589747aee1ef992f63280567f52f5ba870678b4ab4ff6c8ea600bd217870a8b4f1f09f3a8e83 > tmp_cfile
+chksum_ref="68e5db4aa70e55884e6a673a7f4724393a32b2692e3718ef163b7100b34e0550"
+chksum_prep
+
+echo "=== TESTCASE 9k: msig with testnet 2of3, ok ..." | tee -a $logfile
+echo "./$create_cmd -T -v -m 2 3 03834bd129bf0a2e03d53b74bc2eef8d9a5faed93f37b4938ae7127d430804a3cf,03fae2fa202fbfd9d0a8650f537df154158761ce9ad2460793aed74b946babb9f4,038cbc733032dcbed878c727840bef9c2aeb01447e1701c372c46a2ef00f48e02c" >> $logfile
+./$create_cmd -T -v -m 2 3 03834bd129bf0a2e03d53b74bc2eef8d9a5faed93f37b4938ae7127d430804a3cf,03fae2fa202fbfd9d0a8650f537df154158761ce9ad2460793aed74b946babb9f4,038cbc733032dcbed878c727840bef9c2aeb01447e1701c372c46a2ef00f48e02c > tmp_cfile
+chksum_ref="2be34869270668ea187a889fa58ada8e0fa18c939c7f004517b4a7a84c64dffb"
+chksum_prep
+
+echo "=== TESTCASE 9l: msig: https://bitcoin.org/en/developer-examples#p2sh-multisig" | tee -a $logfile
+echo "./$create_cmd -T -v -m 2 3 03310188e911026cf18c3ce274e0ebb5f95b007f230d8cb7d09879d96dbeab1aff,0243930746e6ed6552e03359db521b088134652905bd2d1541fa9124303a41e956,029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255" >> $logfile
+./$create_cmd -T -v -m 2 3 03310188e911026cf18c3ce274e0ebb5f95b007f230d8cb7d09879d96dbeab1aff,0243930746e6ed6552e03359db521b088134652905bd2d1541fa9124303a41e956,029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255 > tmp_cfile
+chksum_ref="f695a0759c67db60aafded1baa4d577f1073bb0e49b67db876f6aa71afeaaa0a"
+chksum_prep
+
+echo "=== TESTCASE 9m: msig: tbd ..." | tee -a $logfile
+echo "./$create_cmd -T -v -m 2 3 ..." >> $logfile
+./$create_cmd -T -v -m 2 3 ... > tmp_cfile
+chksum_ref="b1e36ee999653b286a9dd3854ce822ce266008c398b3df79bf348724314115d8"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase10() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 10: -r testing, for multisig TX creation (P2SH) ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 10a: msig, -r -c, missing redeem script"             | tee -a $logfile
+echo "./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 " >> $logfile
+./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 > tmp_cfile
+chksum_ref="3a113d66d0eca765a9a643e29d6666660743cd6bf351717743c40ac72ef0f630"
+chksum_prep
+
+echo "=== TESTCASE 10b: msig, -r -c, short redeem script (<=20 Bytes)"  | tee -a $logfile
+echo "./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1234567890 " >> $logfile
+./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 1234567890 > tmp_cfile
+chksum_ref="2397e5005abae805d4a9526ab1774a52ef80babeb19b5ab719a8f1ae6341c37f"
+chksum_prep
+
+
+echo "=== TESTCASE 10i: msig, copy of 9i, executing with -r ..."        | tee -a $logfile
+echo "    https://gist.githubusercontent.com/gavinandresen/3966071/raw/" >> $logfile
+echo "    1f6cfa4208bc82ee5039876b4f065a705ce64df7/TwoOfThree.sh"        >> $logfile
+echo "./$create_cmd -v -m 2 3 0491bba2510912a5bd37da1fb5b1673010e43d2c6d812c514e91bfa9f2eb129e1c183329db55bd868e209aac2fbc02cb33d98fe74bf23f0c235d6126b1d8334f86,04865c40293a680cb9c020e7b1e106d8c1916d3cef99aa431a56d253e69256dac09ef122b1a986818a7cb624532f062c1d1f8722084861c5c3291ccffef4ec6874,048d2455d2403e08708fc1f556002f1b6cd83f992d085097f9974ab08a28838f07896fbab08f39495e15fa6fad6edbfb1e754e35fa1c7844c41f322a1863d46213" >> $logfile
+./$create_cmd -v -m 2 3 0491bba2510912a5bd37da1fb5b1673010e43d2c6d812c514e91bfa9f2eb129e1c183329db55bd868e209aac2fbc02cb33d98fe74bf23f0c235d6126b1d8334f86,04865c40293a680cb9c020e7b1e106d8c1916d3cef99aa431a56d253e69256dac09ef122b1a986818a7cb624532f062c1d1f8722084861c5c3291ccffef4ec6874,048d2455d2403e08708fc1f556002f1b6cd83f992d085097f9974ab08a28838f07896fbab08f39495e15fa6fad6edbfb1e754e35fa1c7844c41f322a1863d46213 > tmp_cfile
+ref_redeemscripthash=$( tail -n3 tmp_cfile | head -n1 )
+ref_P2SH_address=$( tail -n1 tmp_cfile )
+echo "./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash " >> $logfile
+./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash > tmp_cfile
+echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u > tmp_cfile
+redeemscripthash=$( tail -n6 tmp_cfile | head -n 1 | cut -f 5 -d " " )
+P2SH_address=$( tail -n4 tmp_cfile | head -n 1 )
+echo "reference: $ref_redeemscripthash" > tmp_cfile
+echo "reference: $ref_P2SH_address"    >> tmp_cfile
+echo "result:    $redeemscripthash"    >> tmp_cfile
+echo "result:    $P2SH_address"        >> tmp_cfile
+if [ "$ref_P2SH_address" == "$P2SH_address" ] ; then
+  echo "ok" >> tmp_cfile
+else
+  echo "fail" >> tmp_cfile
+fi
+chksum_ref="ce1999f3d24690da82c17bde52ac0d414e69c8c5c630f2ca9342f1895a662208"
+chksum_prep
+
+echo "=== TESTCASE 10j: msig, copy of 9j, executing with -p ..."        | tee -a $logfile
+echo "./$create_cmd -v -m 2 3 04a882d414e478039cd5b52a92ffb13dd5e6bd4515497439dffd691a0f12af9575fa349b5694ed3155b136f09e63975a1700c9f4d4df849323dac06cf3bd6458cd,046ce31db9bdd543e72fe3039a1f1c047dab87037c36a669ff90e28da1848f640de68c2fe913d363a51154a0c62d7adea1b822d05035077418267b1a1379790187,0411ffd36c70776538d079fbae117dc38effafb33304af83ce4894589747aee1ef992f63280567f52f5ba870678b4ab4ff6c8ea600bd217870a8b4f1f09f3a8e83" >> $logfile
+./$create_cmd -v -m 2 3 04a882d414e478039cd5b52a92ffb13dd5e6bd4515497439dffd691a0f12af9575fa349b5694ed3155b136f09e63975a1700c9f4d4df849323dac06cf3bd6458cd,046ce31db9bdd543e72fe3039a1f1c047dab87037c36a669ff90e28da1848f640de68c2fe913d363a51154a0c62d7adea1b822d05035077418267b1a1379790187,0411ffd36c70776538d079fbae117dc38effafb33304af83ce4894589747aee1ef992f63280567f52f5ba870678b4ab4ff6c8ea600bd217870a8b4f1f09f3a8e83 > tmp_cfile
+ref_redeemscripthash=$( tail -n3 tmp_cfile | head -n1 )
+ref_P2SH_address=$( tail -n1 tmp_cfile )
+echo "./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash" >> $logfile
+./$create_cmd -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash > tmp_cfile
+echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u > tmp_cfile
+redeemscripthash=$( tail -n6 tmp_cfile | head -n 1 | cut -f 5 -d " " )
+P2SH_address=$( tail -n4 tmp_cfile | head -n 1 )
+echo "reference: $ref_redeemscripthash" > tmp_cfile
+echo "reference: $ref_P2SH_address"    >> tmp_cfile
+echo "result:    $redeemscripthash"    >> tmp_cfile
+echo "result:    $P2SH_address"        >> tmp_cfile
+if [ "$ref_P2SH_address" == "$P2SH_address" ] ; then
+  echo "ok" >> tmp_cfile
+else
+  echo "fail" >> tmp_cfile
+fi
+chksum_ref="4583880713530f43f4612a51ed03205f3a7e84ae9b97b762b1f88161b484515f"
+chksum_prep
+
+echo "=== TESTCASE 10k: msig, copy of 9k, executing with -p ..."        | tee -a $logfile
+echo "./$create_cmd -T -v -m 2 3 03834bd129bf0a2e03d53b74bc2eef8d9a5faed93f37b4938ae7127d430804a3cf,03fae2fa202fbfd9d0a8650f537df154158761ce9ad2460793aed74b946babb9f4,038cbc733032dcbed878c727840bef9c2aeb01447e1701c372c46a2ef00f48e02c" >> $logfile
+./$create_cmd -T -v -m 2 3 03834bd129bf0a2e03d53b74bc2eef8d9a5faed93f37b4938ae7127d430804a3cf,03fae2fa202fbfd9d0a8650f537df154158761ce9ad2460793aed74b946babb9f4,038cbc733032dcbed878c727840bef9c2aeb01447e1701c372c46a2ef00f48e02c > tmp_cfile
+ref_redeemscripthash=$( tail -n3 tmp_cfile | head -n1 )
+ref_P2SH_address=$( tail -n1 tmp_cfile )
+echo "./$create_cmd -T -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash" >> $logfile
+./$create_cmd -T -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash > tmp_cfile
+echo "./tcls_tx2txt.sh -T -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -T -vv -f tmp_c_utx.txt -u > tmp_cfile
+redeemscripthash=$( tail -n6 tmp_cfile | head -n 1 | cut -f 5 -d " " )
+P2SH_address=$( tail -n4 tmp_cfile | head -n 1 )
+echo "reference: $ref_redeemscripthash" > tmp_cfile
+echo "reference: $ref_P2SH_address"    >> tmp_cfile
+echo "result:    $redeemscripthash"    >> tmp_cfile
+echo "result:    $P2SH_address"        >> tmp_cfile
+if [ "$ref_P2SH_address" == "$P2SH_address" ] ; then
+  echo "ok" >> tmp_cfile
+else
+  echo "fail" >> tmp_cfile
+fi
+chksum_ref="fa779abdfa215fa1cabb27654928f9f5dba4089909f407c19fb132cf811384ad" 
+chksum_prep
+
+echo "=== TESTCASE 10l: msig, copy of 9l, executing with -p ..."        | tee -a $logfile
+echo "./$create_cmd -T -v -m 2 3 03310188e911026cf18c3ce274e0ebb5f95b007f230d8cb7d09879d96dbeab1aff,0243930746e6ed6552e03359db521b088134652905bd2d1541fa9124303a41e956,029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255" >> $logfile
+./$create_cmd -T -v -m 2 3 03310188e911026cf18c3ce274e0ebb5f95b007f230d8cb7d09879d96dbeab1aff,0243930746e6ed6552e03359db521b088134652905bd2d1541fa9124303a41e956,029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255 > tmp_cfile
+ref_redeemscripthash=$( tail -n3 tmp_cfile | head -n1 )
+ref_P2SH_address=$( tail -n1 tmp_cfile )
+echo "./$create_cmd -T -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash" >> $logfile
+./$create_cmd -T -vv -r -c F2B3EB2DEB76566E7324307CD47C35EEB88413F971D88519859B1834307ECFEC 1 76a914010966776006953d5567439e5e39f86a0d273bee88ac 99900000 $ref_redeemscripthash > tmp_cfile
+echo "./tcls_tx2txt.sh -T -vv -f tmp_c_utx.txt -u" >> $logfile
+./tcls_tx2txt.sh -T -vv -f tmp_c_utx.txt -u > tmp_cfile
+redeemscripthash=$( tail -n6 tmp_cfile | head -n 1 | cut -f 5 -d " " )
+P2SH_address=$( tail -n4 tmp_cfile | head -n 1 )
+echo "reference: $ref_redeemscripthash" > tmp_cfile
+echo "reference: $ref_P2SH_address"    >> tmp_cfile
+echo "result:    $redeemscripthash"    >> tmp_cfile
+echo "result:    $P2SH_address"        >> tmp_cfile
+if [ "$ref_P2SH_address" == "$P2SH_address" ] ; then
+  echo "ok" >> tmp_cfile
+else
+  echo "fail" >> tmp_cfile
+fi
+chksum_ref="7b29169e5b53d0977709f18cc302e4a8202bc7a3f604a369987a62f3d8281bd9"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+all_testcases() {
+  testcase1 
+  testcase2 
+  testcase3 
+  testcase4 
+  testcase5 
+  testcase6 
+  testcase7 
+  testcase8 
+  testcase9 
+}
+
+#####################
+### here we start ###
+#####################
+logfile=$0.log
+if [ -f "$logfile" ] ; then rm $logfile; fi
+echo $date > $logfile
+
+###################################################################
+# verify our operating system, cause checksum commands differ ... #
+###################################################################
+OS=$(uname) 
+if [ OS="OpenBSD" ] ; then
+  chksum_cmd=sha256
+fi
+if [ OS="Linux" ] ; then
+  chksum_cmd="openssl sha256"
+fi
+if [ OS="Darwin" ] ; then
+  chksum_cmd="openssl dgst -sha256"
+fi
+
+################################
+# command line params handling #
+################################
+
+if [ $# -eq 0 ] ; then
+  all_testcases
+fi
+
+if [ $# -eq 1 ] && [ "$1" == "-l" ] ; then
+  LOG=1
+  shift
+  all_testcases
+fi
+
+while [ $# -ge 1 ] 
+ do
+  case "$1" in
+  -h)
+     echo "usage: $0 -h|-l [1-9]"
+     echo "  "
+     echo "script does several testcases, mostly with checksums for verification"
+     echo "  "
+     exit 0
+     ;;
+  -l)
+     LOG=1
+     shift
+     ;;
+  1|2|3|4|5|6|7|8|9|10)
+     testcase$1 
+     shift
+     ;;
+  *)
+     echo "unknown parameter(s), try -h, exiting gracefully ..."
+     exit 0
+     ;;
+  esac
+done
+
+# clean up
+for i in tmp*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *hex; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *pem; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+

--- a/tcls_testcases_key2pem.sh
+++ b/tcls_testcases_key2pem.sh
@@ -1,0 +1,287 @@
+#!/bin/sh
+# some testcases for the shell script "tcls_key2pem.sh"
+#
+# Copyright (c) 2015, 2016 Volker Nowarra 
+# updated regularly with the root shell script
+# 
+# Permission to use, copy, modify, and distribute this software for any 
+# purpose with or without fee is hereby granted, provided that the above 
+# copyright notice and this permission notice appear in all copies. 
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY 
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER 
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE 
+# USE OR PERFORMANCE OF THIS SOFTWARE. 
+# 
+
+typeset -i LOG=0
+logfile=$0.log
+
+chksum_verify() {
+if [ "$1" == "$2" ] ; then
+  echo "ok"
+else
+  echo $1 | tee -a $logfile
+  echo "*************** checksum  mismatch, ref is: ********************" | tee -a $logfile
+  echo $2 | tee -a $logfile
+  echo " " | tee -a $logfile
+fi
+}
+
+to_logfile() {
+  # echo $chksum_ref >> $logfile
+  cat tmp_tx_cfile >> $logfile
+  echo " " >> $logfile
+}
+
+chksum_prep() {
+result=$( $chksum_cmd tmp_tx_cfile | cut -d " " -f 2 )
+chksum_verify "$result" "$chksum_ref"
+if [ $LOG -eq 1 ] ; then to_logfile ; fi
+}
+
+testcase1() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 1: get the checksums of all necessary files  ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+
+echo "TESTCASE 1a: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
+cp tcls_key2pem.sh tmp_tx_cfile
+chksum_ref="736af2ceeb382639f271abfe8cde580ebce816b98ae149037a95a2268ba7d893"
+chksum_prep
+
+echo "TESTCASE 1b: $chksum_cmd tcls_verify_bc_address.awk" | tee -a $logfile
+cp tcls_verify_bc_address.awk tmp_tx_cfile
+chksum_ref="c944ff89ff49454ca03b0ea8f3ce8ebbd44e33e8d87ab48ae00ad4d6544099f6" 
+chksum_prep
+
+echo "TESTCASE 1c: $chksum_cmd tcls_verify_hexkey.awk" | tee -a $logfile
+cp tcls_verify_hexkey.awk tmp_tx_cfile
+chksum_ref="055b79074a8f33d0aa9aa7634980d29f4e3eb0248a730ea784c7a88e64aa7cfd" 
+chksum_prep
+echo " " | tee -a $logfile
+
+}
+
+testcase2() {
+# do a testcase with the included example transaction
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 2: parameter checking ...                    ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "===  do a testcase with the parameters set incorrectly,   ===" >> $logfile
+echo "===  and at the end 2 correct settings. This just serves  ===" >> $logfile
+echo "===  to verify, that code is executing properly           ===" >> $logfile
+echo "=============================================================" >> $logfile
+
+echo "TESTCASE 2a: call should fail, cause no param at all" | tee -a $logfile
+echo "./tcls_key2pem.sh " >> $logfile
+./tcls_key2pem.sh > tmp_tx_cfile
+chksum_ref="dab9fd3828a3902487a905101779ddbc2001a4290d9f5259953c52438dd731a8" 
+chksum_prep
+
+echo "TESTCASE 2b: call should fail, cause -w has a wrong parameter" | tee -a $logfile
+echo "./tcls_key2pem.sh -w abc -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352" >> $logfile
+./tcls_key2pem.sh -w abc -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 > tmp_tx_cfile
+chksum_ref="ab158867d386a098bf47e1d632c1013e3267a05ad6360f1d83da6fedd49e33a7"
+chksum_prep
+
+echo "TESTCASE 2c: call should fail, cause -p has wrong parameter"   | tee -a $logfile
+echo "./tcls_key2pem.sh -w 5J1F7GHadZG3sCCKHCwg8Jvys9xUbFsjLnGec4H125Ny1V9nR6V -p abc" >> $logfile
+./tcls_key2pem.sh -w 5J1F7GHadZG3sCCKHCwg8Jvys9xUbFsjLnGec4H125Ny1V9nR6V -p abc > tmp_tx_cfile
+chksum_ref="a6bc46d3fb043166c83256c500e486079bcf6d3bc525c37c15f5d1c29baf6e7b"
+chksum_prep
+
+echo "TESTCASE 2d: call should fail, cause -x has wrong parameter" | tee -a $logfile
+echo "./tcls_key2pem.sh -x abc -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352" >> $logfile
+./tcls_key2pem.sh -x abc -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 > tmp_tx_cfile
+chksum_ref="2a6797b8c5f60fb9c6a3cd5606462a3785f349069e2429f40a8b7d8d773bf1af"
+chksum_prep
+
+echo "TESTCASE 2e: call should fail, cause -p with wrong (wif) format" | tee -a $logfile
+echo "./tcls_key2pem.sh -w 5J1F7GHadZG3sCCKHCwg8Jvys9xUbFsjLnGec4H125Ny1V9nR6V -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352" >> $logfile
+./tcls_key2pem.sh -w 5J1F7GHadZG3sCCKHCwg8Jvys9xUbFsjLnGec4H125Ny1V9nR6V -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 > tmp_tx_cfile
+chksum_ref="31fb1bccf5181bee93c7b66b47eb4511ec095d8860d63a1db9a00d01e59b73a3"
+chksum_prep
+
+echo "TESTCASE 2f: call should fail, cause -p with wrong (wif-c) format" | tee -a $logfile
+echo "./tcls_key2pem.sh -w Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C -p 0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6" >> $logfile
+./tcls_key2pem.sh -w Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C -p 0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6 > tmp_tx_cfile
+chksum_ref="6d7a590de3d9e805f5223be569d8abb79112dd821181a69190d0cd526f8cc47e"
+chksum_prep
+
+echo "TESTCASE 2g: call should work, cause param -q provides minimum output" | tee -a $logfile
+echo "./tcls_key2pem.sh -q -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352" >> $logfile
+./tcls_key2pem.sh -q -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 > tmp_tx_cfile
+if [ $? -eq 0 ] ; then
+  echo " " >> $logfile
+  echo "as the [-q] parameter is given, the call will produce no output, hence in" >> $logfile
+  echo "positive case nothing is displayed, and nothing added to the tmp_tx_cfile." >> $logfile
+  echo "what happens, when something goes wrong, and output is produced? " >> $logfile
+else
+  echo "something went wrong, please check manually" >> $logfile
+fi
+chksum_ref="e16f1596201850fd4a63680b27f603cb64e67176159be3d8ed78a4403fdb1700"
+chksum_prep
+
+echo "TESTCASE 2h: call should work, cause -x works with -p <uncompressed> " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6" >> $logfile
+./tcls_key2pem.sh -v -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6 > tmp_tx_cfile 
+chksum_ref="69fd939a7babeb89584a035d0de76d54cba837128ac49c7b9f88d53354e8e220"
+chksum_prep
+
+echo "TESTCASE 2i: call should work, cause -x works with -p <compressed>"    | tee -a $logfile
+echo "             with '-vv' given, openssl creates new priv/pub key   "    >> $logfile
+echo "             pairs. So we only checksum the first 60 lines of output." >> $logfile
+./tcls_key2pem.sh -vv -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 | head -n60 > tmp_tx_cfile 
+chksum_ref="e1d088e11e92219d422c3ee48baf1c72c324d065dbc05adb7e23c124e0b94219"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase3() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 3: check with hex privkey, wif and wifc      ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "from: http://www.cryptosys.net/pki/ecc-bitcoin-raw-transaction.html" >> $logfile
+
+echo "TESTCASE 3a: with a hex privkey, should just work... " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -x 0ecd20654c2e2be708495853e8da35c664247040c00bd10b9b13e5e86e6a808d -p 042daa93315eebbe2cb9b5c3505df4c6fb6caca8b756786098567550d4820c09db988fe9997d049d687292f815ccd6e7fb5c1b1a91137999818d17c73d0f80aef9" >> $logfile
+./tcls_key2pem.sh -v -x 0ecd20654c2e2be708495853e8da35c664247040c00bd10b9b13e5e86e6a808d -p 042daa93315eebbe2cb9b5c3505df4c6fb6caca8b756786098567550d4820c09db988fe9997d049d687292f815ccd6e7fb5c1b1a91137999818d17c73d0f80aef9 > tmp_tx_cfile
+chksum_ref="5f0a3295bc8108816241ca5b1efae4e424d501f73294dd51bbdbae2ba2aa12f5"
+chksum_prep
+
+echo "TESTCASE 3b: with a wif privkey, should just work... " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -w 5HvofFG7K1e2aeWESm5pbCzRHtCSiZNbfLYXBvxyA57DhKHV4U3 -p 042daa93315eebbe2cb9b5c3505df4c6fb6caca8b756786098567550d4820c09db988fe9997d049d687292f815ccd6e7fb5c1b1a91137999818d17c73d0f80aef9" >> $logfile
+./tcls_key2pem.sh -v -w 5HvofFG7K1e2aeWESm5pbCzRHtCSiZNbfLYXBvxyA57DhKHV4U3 -p 042daa93315eebbe2cb9b5c3505df4c6fb6caca8b756786098567550d4820c09db988fe9997d049d687292f815ccd6e7fb5c1b1a91137999818d17c73d0f80aef9 > tmp_tx_cfile
+chksum_ref="a88e8153b468f9e9aa94a4e89999e468674b91cb464bf59700d641a09df7f719"
+chksum_prep
+
+echo "TESTCASE 3c: with a wif-c privkey, should just work... " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -w KwiUwowgrVpRyWY2LhaH3yvSDWyWWRtKzDG8FFC2s38T2f6gX2Jb -p 032DAA93315EEBBE2CB9B5C3505DF4C6FB6CACA8B756786098567550D4820C09DB" >> $logfile
+./tcls_key2pem.sh -v -w KwiUwowgrVpRyWY2LhaH3yvSDWyWWRtKzDG8FFC2s38T2f6gX2Jb -p 032DAA93315EEBBE2CB9B5C3505DF4C6FB6CACA8B756786098567550D4820C09DB > tmp_tx_cfile
+chksum_ref="16a633b87e29f1fbce9269bc8d6653354c377bfa6c6f1b0b160f6e9966210c12"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase4() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 4: another simple testcase, should just work ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "from: http://bitcoin.stackexchange.com/questions/32628/redeeming-a-raw-transaction-step-by-step-example-required" >> $logfile
+
+echo "TESTCASE 4a: " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352" >> $logfile
+./tcls_key2pem.sh -v -x 18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725 -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 > tmp_tx_cfile
+chksum_ref="0e915e5f11d0f753bfe8713d8497649ab79c3c2199db28798aa5b9a54f979045"
+chksum_prep
+
+echo "TESTCASE 4b: " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -w 5J1F7GHadZG3sCCKHCwg8Jvys9xUbFsjLnGec4H125Ny1V9nR6V -p 0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6" >> $logfile
+./tcls_key2pem.sh -v -w 5J1F7GHadZG3sCCKHCwg8Jvys9xUbFsjLnGec4H125Ny1V9nR6V -p 0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6 > tmp_tx_cfile
+chksum_ref="f6b85f6b60ff9d482853c0a9bee80f9dd4a11e4dde54df3019f05e15bb6cdb60"
+chksum_prep
+
+echo "TESTCASE 4c: " | tee -a $logfile
+echo "./tcls_key2pem.sh -v -w Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352" >> $logfile
+./tcls_key2pem.sh -v -w Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C -p 0250863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B2352 > tmp_tx_cfile
+chksum_ref="a0cb46f651eef358e5bf4bfb97c425110c748e9f963036fa0e88c33bf95e665f"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+echo " "
+echo "=============================================="
+echo "===           KEYHANDLING TESTCASES       ==="
+echo "=============================================="
+echo " "
+
+all_testcases() {
+  testcase1 
+  testcase2 
+  testcase3 
+  testcase4 
+# testcase5 
+# testcase6 
+# testcase7 
+# testcase8 
+# testcase9 
+}
+
+#####################
+### here we start ###
+#####################
+logfile=$0.log
+if [ -f "$logfile" ] ; then rm $logfile; fi
+echo $date > $logfile
+
+###################################################################
+# verify our operating system, cause checksum commands differ ... #
+###################################################################
+OS=$(uname) 
+if [ OS="OpenBSD" ] ; then
+  chksum_cmd=sha256
+fi
+if [ OS="Linux" ] ; then
+  chksum_cmd="openssl sha256"
+fi
+if [ OS="Darwin" ] ; then
+  chksum_cmd="openssl dgst -sha256"
+fi
+
+################################
+# command line params handling #
+################################
+
+if [ $# -eq 0 ] ; then
+  all_testcases
+fi
+
+if [ $# -eq 1 ] && [ "$1" == "-l" ] ; then
+  LOG=1
+  shift
+  all_testcases
+fi
+
+while [ $# -ge 1 ] 
+ do
+  case "$1" in
+  -h|--help)
+     echo "usage: testcases_tcls_key2pem.sh [-?|-h|-l|1-8]"
+     echo "  "
+     echo "script does several testcases, mostly with checksums for verification"
+     echo "  "
+     exit 0
+     ;;
+  -l|--log)
+     LOG=1
+     shift
+     ;;
+  1|2|3|4|5|6|7|8|9)
+     testcase$1 
+     shift
+     ;;
+  *)
+     echo "unknown parameter(s), try -h, exiting gracefully ..."
+     exit 0
+     ;;
+  esac
+done
+
+# clean up
+for i in tmp*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *hex; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *pem; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+

--- a/tcls_testcases_sign.sh
+++ b/tcls_testcases_sign.sh
@@ -1,0 +1,222 @@
+#!/bin/sh
+# some testcases for the shell script "tcls_sign.sh" 
+#
+# Copyright (c) 2015, 2016 Volker Nowarra 
+# updated regularly with the root shell script
+# 
+# Permission to use, copy, modify, and distribute this software for any 
+# purpose with or without fee is hereby granted, provided that the above 
+# copyright notice and this permission notice appear in all copies. 
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY 
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER 
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE 
+# USE OR PERFORMANCE OF THIS SOFTWARE. 
+# 
+
+typeset -i LOG=0
+logfile=$0.log
+
+chksum_verify() {
+if [ "$1" == "$2" ] ; then
+  echo "ok"
+else
+  echo $1 | tee -a $logfile
+  echo "*************** checksum  mismatch, ref is: ********************" | tee -a $logfile
+  echo $2 | tee -a $logfile
+  echo " " | tee -a $logfile
+fi
+}
+
+to_logfile() {
+  # echo $chksum_ref >> $logfile
+  cat tmp_tx_cfile >> $logfile
+  echo " " >> $logfile
+}
+
+chksum_prep() {
+result=$( $chksum_cmd tmp_tx_cfile | cut -d " " -f 2 )
+# echo $result | cut -d " " -f 2 >> $logfile
+chksum_verify "$result" "$chksum_ref" 
+if [ $LOG -eq 1 ] ; then to_logfile ; fi
+}
+
+testcase1() {
+# first get the checksums of all necessary files
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 1: get the checksums of all necessary files     ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+
+echo "=== TESTCASE 1a: $chksum_cmd tcls_sign.sh" | tee -a $logfile
+cp tcls_sign.sh tmp_tx_cfile
+chksum_ref="b81b4698981a15a44b5f9cbbc1f15c783e0c74b275098e504764174b3dc9c862" 
+chksum_prep
+
+echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
+cp tcls_key2pem.sh tmp_tx_cfile
+chksum_ref="736af2ceeb382639f271abfe8cde580ebce816b98ae149037a95a2268ba7d893" 
+chksum_prep
+
+echo "=== TESTCASE 1c: $chksum_cmd tcls_strict_sig_verify.sh" | tee -a $logfile
+cp tcls_strict_sig_verify.sh tmp_tx_cfile
+chksum_ref="f45f17eed63026710b9b238ab8315c1816ec779e44ea0726fa6633897ca2c1f5" 
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+
+testcase2() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 2: parameters testing                           ===" | tee -a $logfile
+echo "=== do several testcases with parameters set incorrectly     ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+
+echo "=== TESTCASE 2a: param file is missing, show correct hint ..."    | tee -a $logfile
+echo "./tcls_sign.sh -f tmp_utx.txt -w XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXQPcN4 -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0" >> $logfile 
+./tcls_sign.sh -f tmp_utx.txt -w XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXQPcN4 -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 > tmp_tx_cfile
+chksum_ref="710d2b7c03bb71cfeea6fc35eaf2675411720888a5390aab89bd9533c72c90fd" 
+chksum_prep
+echo " " | tee -a $logfile
+}
+ 
+
+testcase3() {
+###
+### the script sigs are changing on every call, need to filter result!!
+###
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3: sign a tx, prepared from tcls_create.sh      ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3a: use one TX-In and one TX-Out         " | tee -a $logfile
+echo "===  1 input from: 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM " >> $logfile
+echo "===  1 output to:  13GnHB51piDBf1avocPL7tSKLugK4F7U2B " >> $logfile
+echo "./tcls_sign.sh -v -f tmp_c_utx.txt -w KyP5KEp6DCmF222YM5EB9yGeMFxdVK1QWgtGvWnLRnDmiCtQPcN4 -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0" >> $logfile
+printf "010000000174fb6858c31a292d20c9744187032bddb7ddea02a3aa3ef523c8524a21481881010000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffff01b08f0600000000001976a91418ec49b27624086a2b6f35f263d951d25dbe24b688ac0000000001000000" > tmp_c_utx.txt
+./tcls_sign.sh -v -f tmp_c_utx.txt -w KyP5KEp6DCmF222YM5EB9yGeMFxdVK1QWgtGvWnLRnDmiCtQPcN4 -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 > tmp_cfile
+head -n 38 tmp_cfile > tmp_tx_cfile
+echo " " >> tmp_tx_cfile
+echo "###############################################" >> tmp_tx_cfile
+echo "### signatures and hashes change every time ###" >> tmp_tx_cfile
+echo "### for better verification, we add output  ###" >> tmp_tx_cfile
+echo "### from ./tcls_tx2txt.sh -vv -r ...        ###" >> tmp_tx_cfile
+echo "### but this cannot be part of the checksum ###" >> tmp_tx_cfile
+echo "### --> it is itself changing everytime ... ###" >> tmp_tx_cfile
+echo "###############################################" >> tmp_tx_cfile
+echo " " >> tmp_tx_cfile
+chksum_ref="0bd2ae4ddd09e9cc1fd63150408c24df61eb50225dfa0de0f0f14b5000bdef38" 
+chksum_prep
+./tcls_tx2txt.sh -vv -f tmp_stx.txt > tmp_tcls_tx2txt.out
+#cat tmp_tcls_tx2txt.out >> $tmp_tx_cfile
+cat tmp_tcls_tx2txt.out >> $logfile
+
+echo "=== TESTCASE 3b: use 4 TX-In and 1 TX-Out " | tee -a $logfile
+echo "===  4 inputs from: 1JmPRDELzWZqRBKtdiak3iiyZrPQT3gxcM ===" >> $logfile
+echo "===  1 output to:   13GnHB51piDBf1avocPL7tSKLugK4F7U2B ===" >> $logfile
+echo "./tcls_sign.sh -v -f tmp_c_utx.txt -w KyP5KEp6DCmF222YM5EB9yGeMFxdVK1QWgtGvWnLRnDmiCtQPcN4 -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0" >> $logfile
+printf "0100000004b0772e6ef46c2d3c60418bb7d5c2c015d6b943e5fca07570eb82c26dc7c9d248010000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffff74fb6858c31a292d20c9744187032bddb7ddea02a3aa3ef523c8524a21481881010000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffffcc21e36eedb509c660681c1e949dd294bd4c11692439221004c2235d565b74bb000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffffea919487e04ed509d6cb9c7297c277b9be3a68f3836c7d86df378714a75949e8000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffff01b08f0600000000001976a91418ec49b27624086a2b6f35f263d951d25dbe24b688ac0000000001000000" > tmp_c_utx.txt
+./tcls_sign.sh -v -f tmp_c_utx.txt -w KyP5KEp6DCmF222YM5EB9yGeMFxdVK1QWgtGvWnLRnDmiCtQPcN4 -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 > tmp_cfile
+head -n 69 tmp_cfile > tmp_tx_cfile
+echo " " >> tmp_tx_cfile
+echo "###############################################" >> tmp_tx_cfile
+echo "### signatures and hashes change every time ###" >> tmp_tx_cfile
+echo "### for better verification, we add output  ###" >> tmp_tx_cfile
+echo "### from ./tcls_tx2txt.sh -vv -r ...        ###" >> tmp_tx_cfile
+echo "### but this cannot be part of the checksum ###" >> tmp_tx_cfile
+echo "### --> it is itself changing everytime ... ###" >> tmp_tx_cfile
+echo "###############################################" >> tmp_tx_cfile
+echo " " >> tmp_tx_cfile
+chksum_ref="71cc81927eb4953cb50585298f01a541abc40f10a7031f75c6308d6edfe96598" 
+chksum_prep
+./tcls_tx2txt.sh -vv -f tmp_stx.txt > tmp_tcls_tx2txt.out
+#cat tmp_tcls_tx2txt.out >> $tmp_tx_cfile
+cat tmp_tcls_tx2txt.out >> $logfile
+
+echo " " | tee -a $logfile
+}
+
+
+all_testcases() {
+  testcase1 
+  testcase2 
+  testcase3 
+}
+
+#####################
+### here we start ###
+#####################
+logfile=$0.log
+if [ -f "$logfile" ] ; then rm $logfile; fi
+echo $date > $logfile
+
+###################################################################
+# verify our operating system, cause checksum commands differ ... #
+###################################################################
+OS=$(uname) 
+if [ OS="OpenBSD" ] ; then
+  chksum_cmd=sha256
+fi
+if [ OS="Linux" ] ; then
+  chksum_cmd="openssl sha256"
+fi
+if [ OS="Darwin" ] ; then
+  chksum_cmd="openssl dgst -sha256"
+fi
+
+################################
+# command line params handling #
+################################
+
+if [ $# -eq 0 ] ; then
+  all_testcases
+fi
+
+if [ $# -eq 1 ] && [ "$1" == "-l" ] ; then
+  LOG=1
+  shift
+  all_testcases
+fi
+
+while [ $# -ge 1 ] 
+ do
+  case "$1" in
+  -h)
+     echo "usage: $0 -h|-l [1-9]"
+     echo "  "
+     echo "script does several testcases, mostly with checksums for verification"
+     echo "  "
+     exit 0
+     ;;
+  -l)
+     LOG=1
+     shift
+     ;;
+  1|2|3|4|5|6|7|8|9)
+     testcase$1 
+     shift
+     ;;
+  *)
+     echo "unknown parameter(s), try -h, exiting gracefully ..."
+     exit 0
+     ;;
+  esac
+done
+
+# clean up
+for i in tmp*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *hex; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in priv*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in pub*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+
+

--- a/tcls_testcases_timings.sh
+++ b/tcls_testcases_timings.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# 
+# test script to verify timing (speed) of different operation(s)
+#
+# Copyright (c) 2016 Volker Nowarra
+# Complete rewrite in Nov/Dec 2016
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+# USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+rawtx_fn=tmp_rawtx.txt
+typeset -i i=0
+typeset -i max=100
+
+
+fill_line() {
+  char_length=${#max}
+  case $char_length in
+   1) printf "                       ===" | tee -a $logfile
+      ;;
+   2) printf "                      ===" | tee -a $logfile
+      ;;
+   3) printf "                     ===" | tee -a $logfile
+      ;;
+   4) printf "                    ===" | tee -a $logfile
+      ;;
+   5) printf "                   ===" | tee -a $logfile
+      ;;
+  esac
+  printf "\n" | tee -a $logfile
+}
+  
+prepdata() {
+  echo "./trx_2txt.sh -vv -r 010000000117a14c047d5bcc8c39a5335821c4461d7f737bacb0734db289f0240113372f9f010000006a47304402200e7f6e5b0089770f3bce07c3e71cf239184dcd13b43ab8ac6639b10d6433ffdd0220034e6e45f3f2f791e716ff81761169a7f38f962670e7125ccff787a9c2afeb7d0121020d0fb39080eea3fa2223003c219a16e5e3f050933a7b36db6cbd16d728cb1fceffffffff02e0c81000000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88aca44d2200000000001976a91447ac42e612ea7eae770bac6ff3c0157e94ca00d488ac00000000 | grep -A7 TX_OUT[0] > $rawtx_fn"
+  ./trx_2txt.sh -vv -r 010000000117a14c047d5bcc8c39a5335821c4461d7f737bacb0734db289f0240113372f9f010000006a47304402200e7f6e5b0089770f3bce07c3e71cf239184dcd13b43ab8ac6639b10d6433ffdd0220034e6e45f3f2f791e716ff81761169a7f38f962670e7125ccff787a9c2afeb7d0121020d0fb39080eea3fa2223003c219a16e5e3f050933a7b36db6cbd16d728cb1fceffffffff02e0c81000000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88aca44d2200000000001976a91447ac42e612ea7eae770bac6ff3c0157e94ca00d488ac00000000 | grep -A7 TX_OUT[[]0[]] > $rawtx_fn
+}
+
+testcase1() {
+echo "================================================================" | tee -a $logfile
+printf "=== TESTCASE 1: loop with $max iterations" | tee -a $logfile
+fill_line
+echo "================================================================" | tee -a $logfile
+i=0
+START=`date +%s`
+echo "=== TESTCASE 1a: using grep/cut/tr, start time: $START   ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+while [ $i -lt $max ]
+do
+  PREV_Amount=$( grep -m1 bitcoin $rawtx_fn | cut -d "=" -f 4 | cut -d "," -f 1 )
+  STEP5_SCRIPT_LEN=$( grep -A1 -B1 pk_script $rawtx_fn | head -n1 | cut -b 7,8 )
+  STEP6_SCRIPTSIG=$( grep -A1 -B1 pk_script $rawtx_fn | tail -n1 | tr -d "[:space:]" )
+  RAW_TRX=''
+  i=$(( i + 1 ))
+done
+echo "   PREV_Amount=$PREV_Amount"
+echo "   STEP5_SCRIPT_LEN=$STEP5_SCRIPT_LEN"
+echo "   STEP6_SCRIPTSIG=$STEP6_SCRIPTSIG"
+END=`date +%s`
+echo "loop finished, with end time=$END"
+# ELAPSED=`echo "scale=4 ($END - $START) / 1000000000" | bc`
+ELAPSED=$(( $END - $START ))
+echo "Elapsed time: $ELAPSED"
+}
+
+testcase2() {
+echo "================================================================" | tee -a $logfile
+printf "=== TESTCASE 2: loop with $max iterations" | tee -a $logfile
+fill_line
+echo "================================================================" | tee -a $logfile
+i=0
+START=`date +%s`
+echo "=== TESTCASE 2a: using awk, start time: $START           ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "loop with $max iterations using awk, start time=$START:"
+while [ $i -lt $max ]
+do
+  PREV_Amount=$( awk -F "=|," '/bitcoin/ { print $6 }' $rawtx_fn )
+  STEP5_SCRIPT_LEN=$( awk -F ",|=" 'NR==5 { print $2 }' $rawtx_fn )
+  STEP6_SCRIPTSIG=$( awk '/pk_script/ { getline;print $1}' $rawtx_fn )
+  RAW_TRX=''
+  i=$(( i + 1 ))
+done
+echo "   PREV_Amount=$PREV_Amount"
+echo "   STEP5_SCRIPT_LEN=$STEP5_SCRIPT_LEN"
+echo "   STEP6_SCRIPTSIG=$STEP6_SCRIPTSIG"
+END=`date +%s`
+echo "loop finished, with end time=$END"
+# ELAPSED=`echo "scale=4 ($END - $START) / 1000000000" | bc`
+ELAPSED=$(( $END - $START ))
+echo "Elapsed time: $ELAPSED"
+}
+
+all_testcases() {
+  testcase1 
+  testcase2 
+}
+
+#####################
+### here we start ###
+#####################
+
+
+
+if [ $# -eq 0 ] ; then
+  prepdata
+  all_testcases
+fi
+
+while [ $# -ge 1 ] 
+ do
+  case "$1" in
+  -h)
+     echo "usage: $0 -h [1-9]"
+     echo "  "
+     echo "script does several timing testcases"
+     echo "  "
+     exit 0
+     ;;
+  1|2|3|4|5|6|7|8|9)
+     prepdata
+     testcase$1 
+     shift
+     ;;
+  *)
+     echo "unknown parameter(s), try -h, exiting gracefully ..."
+     exit 0
+     ;;
+  esac
+done
+
+# clean up
+for f in tmp*; do
+  if [ -f "$f" ]; then rm $f ; fi
+done
+
+

--- a/tcls_testcases_tx2txt.sh
+++ b/tcls_testcases_tx2txt.sh
@@ -1,0 +1,567 @@
+#!/bin/sh
+# some testcases for the shell script "tcls_tx2txt.sh" 
+#
+# Copyright (c) 2015, 2016 Volker Nowarra 
+# Complete rewrite in Nov/Dec 2015 
+# 
+# Permission to use, copy, modify, and distribute this software for any 
+# purpose with or without fee is hereby granted, provided that the above 
+# copyright notice and this permission notice appear in all copies. 
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY 
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER 
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE 
+# USE OR PERFORMANCE OF THIS SOFTWARE. 
+# 
+
+typeset -i LOG=0
+logfile=$0.log
+
+chksum_verify() {
+if [ "$1" == "$2" ] ; then
+  echo "ok"
+else
+  echo $1 | tee -a $logfile
+  echo "*************** checksum  mismatch, ref is: ********************" | tee -a $logfile
+  echo $2 | tee -a $logfile
+  echo " " | tee -a $logfile
+fi
+}
+ 
+to_logfile() {
+  # echo $chksum_ref >> $logfile
+  cat tmpfile >> $logfile
+  echo " " >> $logfile
+}
+
+chksum_prep() {
+  result=$( $chksum_cmd tmpfile | cut -d " " -f 2 )
+  # echo $result | cut -d " " -f 2 >> $logfile
+  chksum_verify "$result" "$chksum_ref" 
+  if [ $LOG -eq 1 ] ; then to_logfile ; fi
+}
+
+
+testcase1() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 1: checksums of all necessary files             ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 1a: $chksum_cmd tcls_tx2txt.sh" | tee -a $logfile
+chksum_ref="71ba85e2bb0996d807bd2efd9cb474afd28ef8f89122222ac6e216d5833e026b"
+cp tcls_tx2txt.sh tmpfile
+chksum_prep
+ 
+echo "=== TESTCASE 1b: $chksum_cmd trx_in_sig_script.sh" | tee -a $logfile
+chksum_ref="5ecdd722acf9c95eabc91d4a7160ef781e2729381be009989eba5f9b877a6991" 
+cp tcls_in_sig_script.sh tmpfile
+chksum_prep
+
+echo "=== TESTCASE 1c: $chksum_cmd trx_out_pk_script.sh" | tee -a $logfile
+chksum_ref="d095117580dcfc3d62c94450ea2da83ea6b6c82f121d1cfd5415b5c6fe1dbae3" 
+cp tcls_out_pk_script.sh tmpfile
+chksum_prep
+
+echo "=== TESTCASE 1d: $chksum_cmd tcls_base58check_enc.sh" | tee -a $logfile
+chksum_ref="cbc1ce97e94e22d70aba81145f0dda80d9495428317b675bf078e14e6bffd33e" 
+cp tcls_base58check_enc.sh tmpfile
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase2() {
+# do a testcase with the included example transaction
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 2: parameters testing                           ===" | tee -a $logfile
+echo "=== do several testcases with parameters set incorrectly,    ===" | tee -a $logfile
+echo "=== and at the end 3 correct settings. This just serves      ===" | tee -a $logfile
+echo "=== to verify, that code is executing properly               ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+
+echo "=== TESTCASE 2a: wrong params, xyz unknown: ./tcls_tx2txt.sh xyz" | tee -a $logfile
+./tcls_tx2txt.sh xyz > tmpfile
+chksum_ref="584b2f70a2fe092553e319a0cd457e06698e7bba03ca0009802838c4793738b3" 
+chksum_prep
+
+echo "=== TESTCASE 2b: wrong params, -r witout param: ./tcls_tx2txt.sh -r" | tee -a $logfile
+./tcls_tx2txt.sh -r > tmpfile
+chksum_ref="6242596d0136fef2101d9566fc02dfa5ea9e63076af020742cd47038e5782945" 
+chksum_prep
+
+echo "=== TESTCASE 2c: wrong params, -t witout param: ./tcls_tx2txt.sh -t" | tee -a $logfile
+./tcls_tx2txt.sh -t > tmpfile
+chksum_ref="a548231d5bc61eea18f548d8b63ac4587b0384bc76405784bf9eb1b2c0437c71" 
+chksum_prep
+
+echo "=== TESTCASE 2d: wrong params, -u witout param: ./tcls_tx2txt.sh -u" | tee -a $logfile
+./tcls_tx2txt.sh -u > tmpfile
+chksum_ref="611685688881c2c83dee9910fbbf21e1eb7b90facf599b2e949bc1e339792a18" 
+chksum_prep
+
+echo "=== TESTCASE 2e: wrong params, param abc unknown: ./tcls_tx2txt.sh -r abc" | tee -a $logfile
+./tcls_tx2txt.sh -r abc > tmpfile
+chksum_ref="36b69f0e3ac344a7cc5f867dffa34ad4503789afb4837f4a9fdfa06050af1dbe"
+chksum_prep
+
+echo "=== TESTCASE 2f: wrong params, param abc unknown: ./tcls_tx2txt.sh -t abc" | tee -a $logfile
+./tcls_tx2txt.sh -t abc > tmpfile
+chksum_ref="a44863f60841dd5dcde406c6de79e83b7aa21ff902bfabe6e7f0f2391d2ef10c"
+chksum_prep
+
+echo "=== TESTCASE 2g: wrong params, param abc unknown: ./tcls_tx2txt.sh -u abc" | tee -a $logfile
+./tcls_tx2txt.sh -u abc > tmpfile
+chksum_ref="36b69f0e3ac344a7cc5f867dffa34ad4503789afb4837f4a9fdfa06050af1dbe" 
+chksum_prep
+
+echo "=== TESTCASE 2h: wrong params, -r and -u together: ..." | tee -a $logfile
+./tcls_tx2txt.sh -r 01000000013153f60f294bc14d0481138c1c9627ff71a580b596987a82 -u 01000000013153f60f294bc14d0481138c1c9627ff71a580b596987a82  > tmpfile
+chksum_ref="3cd1e95ea9a161ba8dee7fd957f6a283e1d95ad0f562ac8994d0bf0986219c3e" 
+chksum_prep
+
+echo "=== TESTCASE 2i: wrong params, -t and -u together: ..." | tee -a $logfile
+./tcls_tx2txt.sh -t 7bec4d7ac4510c39e6845b18188f163718d279f69f832612a864dcfb167abc9c -u def > tmpfile
+chksum_ref="3cd1e95ea9a161ba8dee7fd957f6a283e1d95ad0f562ac8994d0bf0986219c3e" 
+chksum_prep
+
+echo "=== TESTCASE 2j: wrong params, -f without param: ./tcls_tx2txt.sh -f " | tee -a $logfile
+./tcls_tx2txt.sh -f > tmpfile
+chksum_ref="35aebd5aff6c4aa9cc5b1510db7d403df0c4221eb58509f9f3576ce0c7503e1a" 
+chksum_prep
+ 
+echo "=== TESTCASE 2k: wrong params, file abc unknown: ./tcls_tx2txt.sh -f abc" | tee -a $logfile
+./tcls_tx2txt.sh -f abc > tmpfile
+chksum_ref="0414167aa53d245a7f3f58c990b87c419df4745095c87d02c0515cfe5ee03718"
+chksum_prep
+ 
+echo "=== TESTCASE 2l: show help: ./tcls_tx2txt.sh -h" | tee -a $logfile
+./tcls_tx2txt.sh -h > tmpfile
+chksum_ref="bbdf2304803a08246f53e62c78a05dde7d7acaac466faf8081bceccf4eceb0ef" 
+chksum_prep
+
+echo "=== TESTCASE 2m: show default: ./tcls_tx2txt.sh" | tee -a $logfile
+./tcls_tx2txt.sh > tmpfile
+chksum_ref="78241272d4657c65966eae49b8f245a20ba2a720ea5cf6c7238cda5b9067d7dd" 
+chksum_prep
+
+echo "=== TESTCASE 2n: show verbose default: ./tcls_tx2txt.sh -v" | tee -a $logfile
+./tcls_tx2txt.sh -v > tmpfile
+chksum_ref="ae8861713d856428ab62ad64e49c05121f0570b84328550e0fe29150d0e0a164" 
+chksum_prep
+
+echo "=== TESTCASE 2o: show very verbose default: ./tcls_tx2txt.sh -vv" | tee -a $logfile
+./tcls_tx2txt.sh -vv > tmpfile
+chksum_ref="dd2b364ccee747db941cbc76c31ec2364a87a4fdc84457ef3ec6d497a9ed31f1" 
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase3() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3: a fairly simple trx, 1 input, 1 output       ===" | tee -a $logfile
+echo "===  we check functionality to load data via -t parameter    ===" | tee -a $logfile
+echo "===  from https://blockchain.info ...                        ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/30375f40adcf361f5b2a5074b615ca75e5696909e8bc2f8e553c69631826fcf6" >> $logfile
+
+echo "=== TESTCASE 3a: ./tcls_tx2txt.sh -t 30375f40ad... " | tee -a $logfile
+./tcls_tx2txt.sh -t 30375f40adcf361f5b2a5074b615ca75e5696909e8bc2f8e553c69631826fcf6 > tmpfile
+chksum_ref="94e85c26bef2ca235fa08292f8e29d6029a94fe5c1417e94b0e32c14341bfcab" 
+chksum_prep
+
+echo "=== TESTCASE 3b: ./tcls_tx2txt.sh -v -t 30375f40ad... " | tee -a $logfile
+./tcls_tx2txt.sh -v -t 30375f40adcf361f5b2a5074b615ca75e5696909e8bc2f8e553c69631826fcf6 > tmpfile
+chksum_ref="850d8839c39fed9e8c857fda579a8f8f72e26f30d844b16c6b7c4c0ad1229a1a" 
+chksum_prep
+
+echo "=== TESTCASE 3c: ./tcls_tx2txt.sh -v -t 30375f40ad... " | tee -a $logfile
+./tcls_tx2txt.sh -vv -t 30375f40adcf361f5b2a5074b615ca75e5696909e8bc2f8e553c69631826fcf6 > tmpfile
+chksum_ref="a3cfb16ff1cb5c87cbabc50898397686537765bb85accbb2df2ab2adfbd8f378" 
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+
+testcase4() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 4: a fairly simple trx, 1 input, 2 outputs      ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/91c91f31b7586b807d0ddc7a1670d10cc34bdef326affc945d4987704c7eed62" >> $logfile
+
+echo "=== TESTCASE 4a: ./tcls_tx2txt.sh -r 010000000117f83..." | tee -a $logfile
+./tcls_tx2txt.sh -r 010000000117f83daeec34cca28b90390b691d278f658b85b20fae29983acda10273cc7d32010000006b483045022100b95be9ab9148d85d47d51d069923272ad5131505b40b8e27211475305c546c6e02202ae8f2386e0d7afa6ab0acfafa78b0e23e669972d6e656b345b69c6d268aecbd0121020b2b582ca9333957cf8457a4a1b46e5337471cc98582fdf37c58a201dba50dd2feffffff0210201600000000001976a91407ddfbe06b04f3867cae654448174ea2f9a173ea88acda924700000000001976a9143940dcd0bfb7ad9bff322405954949c450742cd588accd3d0600 > tmpfile
+chksum_ref="593defc3655a74744c7f0231ce1e219240b7179c054b3576993e4b6e128da46e"
+chksum_prep
+
+echo "=== TESTCASE 4b: same as 4a, reading from file (param -f)" | tee -a $logfile
+echo "010000000117f83daeec34cca28b90390b691d278f658b85b20fae29983acda10273cc7d32010000006b483045022100b95be9ab9148d85d47d51d069923272ad5131505b40b8e27211475305c546c6e02202ae8f2386e0d7afa6ab0acfafa78b0e23e669972d6e656b345b69c6d268aecbd0121020b2b582ca9333957cf8457a4a1b46e5337471cc98582fdf37c58a201dba50dd2feffffff0210201600000000001976a91407ddfbe06b04f3867cae654448174ea2f9a173ea88acda924700000000001976a9143940dcd0bfb7ad9bff322405954949c450742cd588accd3d0600" > tmpfile_4b
+./tcls_tx2txt.sh -f tmpfile_4b > tmpfile
+chksum_ref="593defc3655a74744c7f0231ce1e219240b7179c054b3576993e4b6e128da46e"
+chksum_prep
+
+echo "=== TESTCASE 4c: same as 4a, verbose (param -v)" | tee -a $logfile
+./tcls_tx2txt.sh -v -r 010000000117f83daeec34cca28b90390b691d278f658b85b20fae29983acda10273cc7d32010000006b483045022100b95be9ab9148d85d47d51d069923272ad5131505b40b8e27211475305c546c6e02202ae8f2386e0d7afa6ab0acfafa78b0e23e669972d6e656b345b69c6d268aecbd0121020b2b582ca9333957cf8457a4a1b46e5337471cc98582fdf37c58a201dba50dd2feffffff0210201600000000001976a91407ddfbe06b04f3867cae654448174ea2f9a173ea88acda924700000000001976a9143940dcd0bfb7ad9bff322405954949c450742cd588accd3d0600 > tmpfile
+chksum_ref="d642bdbea60a0fb122ddb9df51deafb37a266264f50aec5b50b5b6dc64539d1c"
+chksum_prep
+
+echo "=== TESTCASE 4d: same as 4a, verbose (param -vv)" | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 010000000117f83daeec34cca28b90390b691d278f658b85b20fae29983acda10273cc7d32010000006b483045022100b95be9ab9148d85d47d51d069923272ad5131505b40b8e27211475305c546c6e02202ae8f2386e0d7afa6ab0acfafa78b0e23e669972d6e656b345b69c6d268aecbd0121020b2b582ca9333957cf8457a4a1b46e5337471cc98582fdf37c58a201dba50dd2feffffff0210201600000000001976a91407ddfbe06b04f3867cae654448174ea2f9a173ea88acda924700000000001976a9143940dcd0bfb7ad9bff322405954949c450742cd588accd3d0600 > tmpfile
+chksum_ref="4ae6560e3e27d38e3c3c45ad773ecc6d4ce6b5add85ddfe5ecfc0237b40f59da"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase5() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 5: a fairly simple trx, 3 inputs, 1 P2SH output ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/4f292aeff2ad2da37b5d5719bf34846938cf96ea7e75c8715bc3edac01b39589" >> $logfile
+
+echo "=== TESTCASE 5a: ./tcls_tx2txt.sh -r 010000000301de569ae..." | tee -a $logfile
+./tcls_tx2txt.sh -r 010000000301de569ae0b3d49dff80f79f7953f87f17f61ca1f6d523e815a58e2b8863d098000000006a47304402203930d1ba339c9692367ae37836b1f21c1431ecb4522e7ce0caa356b9813722dc02204086f7ad81d5d656ab1b6d0fd4709b5759c22c44a0aeb1969c1cdb7c463912fa012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffff97e60e0bec78cf5114238678f0b5eab617ca770752796b4c795c9d3ada772da5000000006a473044022046412e2b3f820f846a5e8f1cc92529cb694cf0d09d35cf0b5128cc7b9bf32a0802207f736b322727babd41793aeedfad41cc0541c0a1693e88b2a620bcd664da8551012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffffce559734242e6a6e0608caa07ee1178d5b9e53e0814d61f002930d78422e8402000000006b4830450221009fab428713fa76057e1bd87381614abc270089ddb23c345b0a56114db0fb8fd30220187a80bedfbb6b23bcf4eaf25017be2efdd64f02a732be9f4846142ad3408798012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffff011005d0010000000017a91469545b58fd41a120da3f606be313e061ea818edf8700000000 > tmpfile
+chksum_ref="cc903e35b79e8d62bda8249557f1bffbb10ec5a1e490d45801d8a5b5d8e7dd02"
+chksum_prep
+
+echo "=== TESTCASE 5b: ./tcls_tx2txt.sh -v -r 010000000301de569ae..." | tee -a $logfile
+./tcls_tx2txt.sh -v -r 010000000301de569ae0b3d49dff80f79f7953f87f17f61ca1f6d523e815a58e2b8863d098000000006a47304402203930d1ba339c9692367ae37836b1f21c1431ecb4522e7ce0caa356b9813722dc02204086f7ad81d5d656ab1b6d0fd4709b5759c22c44a0aeb1969c1cdb7c463912fa012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffff97e60e0bec78cf5114238678f0b5eab617ca770752796b4c795c9d3ada772da5000000006a473044022046412e2b3f820f846a5e8f1cc92529cb694cf0d09d35cf0b5128cc7b9bf32a0802207f736b322727babd41793aeedfad41cc0541c0a1693e88b2a620bcd664da8551012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffffce559734242e6a6e0608caa07ee1178d5b9e53e0814d61f002930d78422e8402000000006b4830450221009fab428713fa76057e1bd87381614abc270089ddb23c345b0a56114db0fb8fd30220187a80bedfbb6b23bcf4eaf25017be2efdd64f02a732be9f4846142ad3408798012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffff011005d0010000000017a91469545b58fd41a120da3f606be313e061ea818edf8700000000 > tmpfile
+chksum_ref="771a37a4b7362acd0fe546c9e72b2bd6b5c88cd9a92875f1efd31b3fcb75a687"
+chksum_prep
+
+echo "=== TESTCASE 5c: ./tcls_tx2txt.sh -vv -r 010000000301de569ae..." | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 010000000301de569ae0b3d49dff80f79f7953f87f17f61ca1f6d523e815a58e2b8863d098000000006a47304402203930d1ba339c9692367ae37836b1f21c1431ecb4522e7ce0caa356b9813722dc02204086f7ad81d5d656ab1b6d0fd4709b5759c22c44a0aeb1969c1cdb7c463912fa012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffff97e60e0bec78cf5114238678f0b5eab617ca770752796b4c795c9d3ada772da5000000006a473044022046412e2b3f820f846a5e8f1cc92529cb694cf0d09d35cf0b5128cc7b9bf32a0802207f736b322727babd41793aeedfad41cc0541c0a1693e88b2a620bcd664da8551012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffffce559734242e6a6e0608caa07ee1178d5b9e53e0814d61f002930d78422e8402000000006b4830450221009fab428713fa76057e1bd87381614abc270089ddb23c345b0a56114db0fb8fd30220187a80bedfbb6b23bcf4eaf25017be2efdd64f02a732be9f4846142ad3408798012103f6bfdba31cf7e059e19a2b0e60670864d24d7dfe0d7f11045756991271dda237ffffffff011005d0010000000017a91469545b58fd41a120da3f606be313e061ea818edf8700000000 > tmpfile
+chksum_ref="712e4a7225b6fcfcc0f05cb64bf9f5bf97cea175e307d231d6cbeab06917e282"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase6() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 6: this trx has 1 input, and 4 outputs          ===" | tee -a $logfile
+echo "=== trx-in sequence = feffffff - what does this mean?        ===" >> $logfile
+echo "=== bitcoin.org: setting all sequence numbers to 0xffffffff  ===" >> $logfile
+echo "=== (the default in Bitcoin Core) can still disable the time ===" >> $logfile
+echo "=== lock, so if you want to use locktime, at least one input ===" >> $logfile
+echo "=== must have a sequence number below the the maximum.       ===" >> $logfile
+echo "================================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/7264f8ba4a85a4780c549bf04a98e8de4c9cb1120cb1dfe8ab85ff6832eff864" >> $logfile
+
+echo "=== TESTCASE 6a: ./tcls_tx2txt.sh -r 0100000001df64d3e79..." | tee -a $logfile
+./tcls_tx2txt.sh -r 0100000001df64d3e790779777de937eea18884e9b131c9910bdb860b1a5cea225b61e3510020000006b48304502210082e594fdd17f4f2995edc180e5373a664eb56f56420f0c8761a27fa612db2a2b02206bcd4763303661c9ccaac3e4e7f6bfc062f17ce4b6b1b479ee067a05e5a578b10121036932969ec8c5cecebc1ff6fc07126f8cb5589ada69db8ca97a4f1291ead8c06bfeffffff04d130ab00000000001976a9141f59b78ccc26b6d84a65b0d362185ac4683197ed88acf0fcf300000000001976a914f12d85961d3a36119c2eaed5ad0e728a789ab59c88acb70aa700000000001976a9142baaf47baf1bd1e3dad3956db536c3f2e87c237b88ac94804707000000001976a914cb1b1d3c8be7db6416c16a1d29db170930970a3088acce3d0600 > tmpfile
+chksum_ref="f660d573d5b8103e9254eefe5e69cb4ef52c28f351657e81f2b31464c30164db"
+chksum_prep
+
+echo "=== TESTCASE 6b: ./tcls_tx2txt.sh -v -r 0100000001df64d3e79..." | tee -a $logfile
+./tcls_tx2txt.sh -v -r 0100000001df64d3e790779777de937eea18884e9b131c9910bdb860b1a5cea225b61e3510020000006b48304502210082e594fdd17f4f2995edc180e5373a664eb56f56420f0c8761a27fa612db2a2b02206bcd4763303661c9ccaac3e4e7f6bfc062f17ce4b6b1b479ee067a05e5a578b10121036932969ec8c5cecebc1ff6fc07126f8cb5589ada69db8ca97a4f1291ead8c06bfeffffff04d130ab00000000001976a9141f59b78ccc26b6d84a65b0d362185ac4683197ed88acf0fcf300000000001976a914f12d85961d3a36119c2eaed5ad0e728a789ab59c88acb70aa700000000001976a9142baaf47baf1bd1e3dad3956db536c3f2e87c237b88ac94804707000000001976a914cb1b1d3c8be7db6416c16a1d29db170930970a3088acce3d0600 > tmpfile
+chksum_ref="cbbab0cdee3e0bb0a1ae37ef337a2aa17ed84d404f4878af1c951f27bdd6fa7d"
+chksum_prep
+
+echo "=== TESTCASE 6c: ./tcls_tx2txt.sh -vv -r 0100000001df64d3e79..." | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 0100000001df64d3e790779777de937eea18884e9b131c9910bdb860b1a5cea225b61e3510020000006b48304502210082e594fdd17f4f2995edc180e5373a664eb56f56420f0c8761a27fa612db2a2b02206bcd4763303661c9ccaac3e4e7f6bfc062f17ce4b6b1b479ee067a05e5a578b10121036932969ec8c5cecebc1ff6fc07126f8cb5589ada69db8ca97a4f1291ead8c06bfeffffff04d130ab00000000001976a9141f59b78ccc26b6d84a65b0d362185ac4683197ed88acf0fcf300000000001976a914f12d85961d3a36119c2eaed5ad0e728a789ab59c88acb70aa700000000001976a9142baaf47baf1bd1e3dad3956db536c3f2e87c237b88ac94804707000000001976a914cb1b1d3c8be7db6416c16a1d29db170930970a3088acce3d0600 > tmpfile
+chksum_ref="4dacd2032cbc00c889d4236c638998ad6c4e6103594ce463a7a8c93d6b61efa2"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+
+testcase7() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 7: this is a transaction to a multisig address  ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/51f7fc9899b068c4a501ffa9b37368fd7c09b3e72e893e989c40c89095f74b79" >> $logfile
+
+echo "=== TESTCASE 7a: " | tee -a $logfile
+./tcls_tx2txt.sh -r 010000000216f7342825c156476c430f3e2765e0c393283b08246a66d122a45c836554ef03010000006b483045022100dd55b040174c90e85f0d33417dfccd96fa4f6b5ef50c32a1b720c24efc097f73022018d8a6b003b46c578d42ff4221af46068b64dd4e55d2d074175038a6e620e66b012103a86d6cd289a76d1b2b13d362d9f58d1753dd4252be1ef8a404831dd1de45f6c2ffffffffe18f73b450139de5c7375dcd2bd249ef6a42ad19661104df796dccdc98d34722000000006a47304402202e733dd23eb16130c3aa705cd04ffa31928616f2558063281cf642d786bf3eef022010a4d48968c504391c19c1cf67163d5618809bacb644d797a24a05f2130aa9f7012103a86d6cd289a76d1b2b13d362d9f58d1753dd4252be1ef8a404831dd1de45f6c2ffffffff02a6ea17000000000017a914f815b036d9bbbce5e9f2a00abd1bf3dc91e9551087413c0200000000001976a914ff57cb19528c04096067b8db38d18ecd0b37789388ac00000000 > tmpfile
+chksum_ref="3dd5bf5b82de43691fae6578672a7625741150a6088caa76acf049a469f648de"
+chksum_prep
+
+echo "=== TESTCASE 7b: " | tee -a $logfile
+./tcls_tx2txt.sh -v -r 010000000216f7342825c156476c430f3e2765e0c393283b08246a66d122a45c836554ef03010000006b483045022100dd55b040174c90e85f0d33417dfccd96fa4f6b5ef50c32a1b720c24efc097f73022018d8a6b003b46c578d42ff4221af46068b64dd4e55d2d074175038a6e620e66b012103a86d6cd289a76d1b2b13d362d9f58d1753dd4252be1ef8a404831dd1de45f6c2ffffffffe18f73b450139de5c7375dcd2bd249ef6a42ad19661104df796dccdc98d34722000000006a47304402202e733dd23eb16130c3aa705cd04ffa31928616f2558063281cf642d786bf3eef022010a4d48968c504391c19c1cf67163d5618809bacb644d797a24a05f2130aa9f7012103a86d6cd289a76d1b2b13d362d9f58d1753dd4252be1ef8a404831dd1de45f6c2ffffffff02a6ea17000000000017a914f815b036d9bbbce5e9f2a00abd1bf3dc91e9551087413c0200000000001976a914ff57cb19528c04096067b8db38d18ecd0b37789388ac00000000 > tmpfile
+chksum_ref="9a4b23d22fa9da5deda343220edc20ba7eada5607063df9a6eeae8880877108f"
+chksum_prep
+
+echo "=== TESTCASE 7c: " | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 010000000216f7342825c156476c430f3e2765e0c393283b08246a66d122a45c836554ef03010000006b483045022100dd55b040174c90e85f0d33417dfccd96fa4f6b5ef50c32a1b720c24efc097f73022018d8a6b003b46c578d42ff4221af46068b64dd4e55d2d074175038a6e620e66b012103a86d6cd289a76d1b2b13d362d9f58d1753dd4252be1ef8a404831dd1de45f6c2ffffffffe18f73b450139de5c7375dcd2bd249ef6a42ad19661104df796dccdc98d34722000000006a47304402202e733dd23eb16130c3aa705cd04ffa31928616f2558063281cf642d786bf3eef022010a4d48968c504391c19c1cf67163d5618809bacb644d797a24a05f2130aa9f7012103a86d6cd289a76d1b2b13d362d9f58d1753dd4252be1ef8a404831dd1de45f6c2ffffffff02a6ea17000000000017a914f815b036d9bbbce5e9f2a00abd1bf3dc91e9551087413c0200000000001976a914ff57cb19528c04096067b8db38d18ecd0b37789388ac00000000 > tmpfile
+chksum_ref="3ee7be2c23dcab4d781d3d23ddb48cfe12e073831ae289480b877942fdfed4b1"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+
+testcase8() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 8: just another multisig trx                    ===" | tee -a $logfile
+echo "===  Here we have a multisig in and out address ...          ===" >> $logfile
+echo "================================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/c0889855c93eed67d1f5a6b8a31e446e3327ce03bc267f2db958e79802941c73" >> $logfile
+
+echo "=== TESTCASE 8a: " | tee -a $logfile
+./tcls_tx2txt.sh -r 0100000001b9c6777f2d8d710f1e0e3bb5fbffa7cdfd6c814a2257a7cfced9a2205448dd0601000000da0048304502210083a93c7611f5aeee6b0b4d1cbff2d31556af4cd1f951de8341c768ae03f780730220063b5e6dfb461291b1fbd93d58a8111d04fd03c7098834bac5cdf1d3c5fa90d0014730440220137c7320e03b73da66e9cf89e5f5ed0d5743ebc65e776707b8385ff93039408802202c30bc57010b3dd20507393ebc79affc653473a7baf03c5abf19c14e2136c646014752210285cb139a82dd9062b9ac1091cb1f91a01c11ab9c6a46bd09d0754dab86a38cc9210328c37f938748dcbbf15a0e5a9d1ba20f93f2c2d0ead63c7c14a5a10959b5ce8952aeffffffff0280c42b03000000001976a914d199925b52d367220b1e2a2d8815e635b571512f88ac65a7b3010000000017a9145c4dd14b9df138840b34237fdbe9159c420edbbe8700000000 > tmpfile
+chksum_ref="4ec287beb077254801219521cc050d52dd3e4b15c0d89fc86060bf94f676ba2b"
+chksum_prep
+
+echo "=== TESTCASE 8b: " | tee -a $logfile
+./tcls_tx2txt.sh -v -r 0100000001b9c6777f2d8d710f1e0e3bb5fbffa7cdfd6c814a2257a7cfced9a2205448dd0601000000da0048304502210083a93c7611f5aeee6b0b4d1cbff2d31556af4cd1f951de8341c768ae03f780730220063b5e6dfb461291b1fbd93d58a8111d04fd03c7098834bac5cdf1d3c5fa90d0014730440220137c7320e03b73da66e9cf89e5f5ed0d5743ebc65e776707b8385ff93039408802202c30bc57010b3dd20507393ebc79affc653473a7baf03c5abf19c14e2136c646014752210285cb139a82dd9062b9ac1091cb1f91a01c11ab9c6a46bd09d0754dab86a38cc9210328c37f938748dcbbf15a0e5a9d1ba20f93f2c2d0ead63c7c14a5a10959b5ce8952aeffffffff0280c42b03000000001976a914d199925b52d367220b1e2a2d8815e635b571512f88ac65a7b3010000000017a9145c4dd14b9df138840b34237fdbe9159c420edbbe8700000000 > tmpfile
+chksum_ref="06e23cda36decc7626aa9bce3af408145f8c46568533ed426737c2241c1bc43b"
+chksum_prep
+
+echo "=== TESTCASE 8c: " | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 0100000001b9c6777f2d8d710f1e0e3bb5fbffa7cdfd6c814a2257a7cfced9a2205448dd0601000000da0048304502210083a93c7611f5aeee6b0b4d1cbff2d31556af4cd1f951de8341c768ae03f780730220063b5e6dfb461291b1fbd93d58a8111d04fd03c7098834bac5cdf1d3c5fa90d0014730440220137c7320e03b73da66e9cf89e5f5ed0d5743ebc65e776707b8385ff93039408802202c30bc57010b3dd20507393ebc79affc653473a7baf03c5abf19c14e2136c646014752210285cb139a82dd9062b9ac1091cb1f91a01c11ab9c6a46bd09d0754dab86a38cc9210328c37f938748dcbbf15a0e5a9d1ba20f93f2c2d0ead63c7c14a5a10959b5ce8952aeffffffff0280c42b03000000001976a914d199925b52d367220b1e2a2d8815e635b571512f88ac65a7b3010000000017a9145c4dd14b9df138840b34237fdbe9159c420edbbe8700000000 > tmpfile
+chksum_ref="93437c72e6fadb69653fece13802c70bb23647ff288016f19e247bbae4627225"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+
+testcase9() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 9: 4 inputs and 2 outputs (P2SH multisig!)   ===" | tee -a $logfile
+echo "===  This is a long transaction, which is fetched via     ===" >> $logfile
+echo "===  the -t parameter.                                    ===" >> $logfile
+echo "=============================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/734c48124d391bfff5750bbc39bd18e6988e8ac873c418d64d31cfdc31cc64ac" >> $logfile
+
+echo "=== TESTCASE 9a: " | tee -a $logfile
+./tcls_tx2txt.sh -t 734c48124d391bfff5750bbc39bd18e6988e8ac873c418d64d31cfdc31cc64ac > tmpfile
+chksum_ref="784758b228e35689736e16bdb21280790372feb16f954016f717ae421cd3389e"
+chksum_prep
+
+echo "=== TESTCASE 9b: " | tee -a $logfile
+./tcls_tx2txt.sh -v -t 734c48124d391bfff5750bbc39bd18e6988e8ac873c418d64d31cfdc31cc64ac > tmpfile
+chksum_ref="af1f155f2f48be260ae8ba1d542eb8024069ea85b2d7e9ae0883e73e838537ea"
+chksum_prep
+
+echo "=== TESTCASE 9c: " | tee -a $logfile
+./tcls_tx2txt.sh -vv -t 734c48124d391bfff5750bbc39bd18e6988e8ac873c418d64d31cfdc31cc64ac > tmpfile
+chksum_ref="ad1b404adbe731ca758ff49b748108d6145355c9a8bdfffe2ad67ca59c135745"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+
+testcase10() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 10: 1 input, 4 outputs (one is P2SH script)  ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "https://blockchain.info/de/rawtx/ea9462053d74024ec46dac07c450200194051020698e8640a5a024d8ac085590" >> $logfile
+
+echo "=== TESTCASE 10a: " | tee -a $logfile
+./tcls_tx2txt.sh -r 01000000013153f60f294bc14d0481138c1c9627ff71a580b596987a82e9eebf2ae3de232202000000fc0047304402200c2f9e8805de97fa785b93dcc9072197bf5c1095ea536320ed26c645ec3bfafc02202882258f394449f1b1365ce80eed26fbe01217657729664af6827d041e7e98510147304402206d5cbef275b6972bd8cc00aff666a6ca18f09a5b1d1bf49e6966ad815db7119a0220340e49d4b747c9bd8ac80dbe073525c57da43dc4d2727b789be7e66bed9c6d02014c695221037b7c16024e2e6f6575b7a8c55c581dce7effcd6045bdf196461be8ff88db24f1210223eefa59f9b51ca96e1f4710df3639c58aae32c4cef1dd0333e7478de3dd4c6321034d03a7e6806e734c171be535999239aac76822427c217ee7564ab752cdc12dde53aeffffffff048d40ad120100000017a914fb8e0ce6d2f35c566908fd225b7f96e72df603d3872d5f0000000000001976a914768ac2a2530b2987d2e6506edc71dcf9f0a7b6e688ac00350c00000000001976a91452f28673c5aed9126b91d9eac5cbe1e02276a2cb88ac18b30700000000001976a914f3678c60ec389c7b132b5e5b0e1434b6dcd48f4188ac00000000 > tmpfile
+chksum_ref="9bd3e8ba86a0f40d3053362987f24b366f53e5a020a0ccfa30baa1ef42023291"
+chksum_prep
+
+echo "=== TESTCASE 10b: " | tee -a $logfile
+./tcls_tx2txt.sh -v -r 01000000013153f60f294bc14d0481138c1c9627ff71a580b596987a82e9eebf2ae3de232202000000fc0047304402200c2f9e8805de97fa785b93dcc9072197bf5c1095ea536320ed26c645ec3bfafc02202882258f394449f1b1365ce80eed26fbe01217657729664af6827d041e7e98510147304402206d5cbef275b6972bd8cc00aff666a6ca18f09a5b1d1bf49e6966ad815db7119a0220340e49d4b747c9bd8ac80dbe073525c57da43dc4d2727b789be7e66bed9c6d02014c695221037b7c16024e2e6f6575b7a8c55c581dce7effcd6045bdf196461be8ff88db24f1210223eefa59f9b51ca96e1f4710df3639c58aae32c4cef1dd0333e7478de3dd4c6321034d03a7e6806e734c171be535999239aac76822427c217ee7564ab752cdc12dde53aeffffffff048d40ad120100000017a914fb8e0ce6d2f35c566908fd225b7f96e72df603d3872d5f0000000000001976a914768ac2a2530b2987d2e6506edc71dcf9f0a7b6e688ac00350c00000000001976a91452f28673c5aed9126b91d9eac5cbe1e02276a2cb88ac18b30700000000001976a914f3678c60ec389c7b132b5e5b0e1434b6dcd48f4188ac00000000 > tmpfile
+chksum_ref="df361dc2a1752aa9433e0a432495b83cb881caa8d4e71419183d2b65145b9bea"
+chksum_prep
+
+echo "=== TESTCASE 10c: " | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 01000000013153f60f294bc14d0481138c1c9627ff71a580b596987a82e9eebf2ae3de232202000000fc0047304402200c2f9e8805de97fa785b93dcc9072197bf5c1095ea536320ed26c645ec3bfafc02202882258f394449f1b1365ce80eed26fbe01217657729664af6827d041e7e98510147304402206d5cbef275b6972bd8cc00aff666a6ca18f09a5b1d1bf49e6966ad815db7119a0220340e49d4b747c9bd8ac80dbe073525c57da43dc4d2727b789be7e66bed9c6d02014c695221037b7c16024e2e6f6575b7a8c55c581dce7effcd6045bdf196461be8ff88db24f1210223eefa59f9b51ca96e1f4710df3639c58aae32c4cef1dd0333e7478de3dd4c6321034d03a7e6806e734c171be535999239aac76822427c217ee7564ab752cdc12dde53aeffffffff048d40ad120100000017a914fb8e0ce6d2f35c566908fd225b7f96e72df603d3872d5f0000000000001976a914768ac2a2530b2987d2e6506edc71dcf9f0a7b6e688ac00350c00000000001976a91452f28673c5aed9126b91d9eac5cbe1e02276a2cb88ac18b30700000000001976a914f3678c60ec389c7b132b5e5b0e1434b6dcd48f4188ac00000000 > tmpfile
+chksum_ref="73f4789cc055f430d4220069b2146fc4dac32379ecf411ed48e1f2fd214b66bc"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase11() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 11: *** my first cold storage test ! ***     ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 11a: " | tee -a $logfile
+./tcls_tx2txt.sh -u 0100000001bc12683c21e46c380933e83c00ec3929453e3d11cc5a2db9f795372efe03e81d000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffff01d0a11000000000001976a9140de4457d577bb45dee513bb695bdfdc3b34d467d88ac0000000001000000 > tmpfile
+chksum_ref="991460a177a696c201044940b7dd87509f96d4c8494622525473f6c829c17efd"
+chksum_prep
+
+echo "=== TESTCASE 11b: " | tee -a $logfile
+./tcls_tx2txt.sh -v -u 0100000001bc12683c21e46c380933e83c00ec3929453e3d11cc5a2db9f795372efe03e81d000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffff01d0a11000000000001976a9140de4457d577bb45dee513bb695bdfdc3b34d467d88ac0000000001000000 > tmpfile
+chksum_ref="dbbf881368a7a53f97388ae1fce2d229fc280db61a996fc768557aa990c91590"
+chksum_prep
+
+echo "=== TESTCASE 11c: " | tee -a $logfile
+./tcls_tx2txt.sh -vv -u 0100000001bc12683c21e46c380933e83c00ec3929453e3d11cc5a2db9f795372efe03e81d000000001976a914c2df275d78e506e17691fd6f0c63c43d15c897fc88acffffffff01d0a11000000000001976a9140de4457d577bb45dee513bb695bdfdc3b34d467d88ac0000000001000000 > tmpfile
+chksum_ref="6c6b1f7db6da5a0eae6a61521664dbb631ead9809da44f25e0a9c8622751a8ae"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase12() {
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 12: some special trx ...                     ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 12a: the pizza transaction:" | tee -a $logfile
+echo "https://blockchain.info/tx/cca7507897abc89628f450e8b1e0c6fca4ec3f7b34cccf55f3f531c659ff4d79" >> $logfile
+echo "http://bitcoin.stackexchange.com/questions/32305/how-does-the-ecdsa-verification-algorithm-work-during-transaction/32308#32308" >> $logfile
+echo "./tcls_tx2txt.sh -vv -r 01000000018dd4f5fbd5e980fc02f35c6ce145935b11e284605bf599a13c6d415db55d07a1000000008b4830450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e0141042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabbffffffff0200719a81860000001976a914df1bd49a6c9e34dfa8631f2c54cf39986027501b88ac009f0a5362000000434104cd5e9726e6afeae357b1806be25a4c3d3811775835d235417ea746b7db9eeab33cf01674b944c64561ce3388fa1abd0fa88b06c44ce81e2234aa70fe578d455dac00000000" >> $logfile
+./tcls_tx2txt.sh -vv -r 01000000018dd4f5fbd5e980fc02f35c6ce145935b11e284605bf599a13c6d415db55d07a1000000008b4830450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e0141042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabbffffffff0200719a81860000001976a914df1bd49a6c9e34dfa8631f2c54cf39986027501b88ac009f0a5362000000434104cd5e9726e6afeae357b1806be25a4c3d3811775835d235417ea746b7db9eeab33cf01674b944c64561ce3388fa1abd0fa88b06c44ce81e2234aa70fe578d455dac00000000 > tmpfile
+chksum_ref="be4c1321c582d2171be6e936da7fd5e49f56cd62b33e07d9ea5e630a43602f39"
+chksum_prep
+
+echo "=== TESTCASE 12b: the same pizza tx, but fetched from network" | tee -a $logfile
+echo "./tcls_tx2txt.sh -vv -t cca7507897abc89628f450e8b1e0c6fca4ec3f7b34cccf55f3f531c659ff4d79" >> $logfile
+./tcls_tx2txt.sh -vv -t cca7507897abc89628f450e8b1e0c6fca4ec3f7b34cccf55f3f531c659ff4d79 > tmpfile
+chksum_ref="3a422492912d5bc4c3e95c9978fb00296e0eff6cd8515cd65bb1bd0a2532b1bc"
+chksum_prep
+
+echo "=== TESTCASE 12c: nice tx_out script:" | tee -a $logfile
+echo "http://bitcoin.stackexchange.com/questions/48673/confused-about-this-particular-multisig-transaction-with-a-maybe-invalid-scrip" >> $logfile
+echo "./tcls_tx2txt.sh -vv -t c49b3c445c89d832289de0fd3b0281efdcce418333dacd028061e8de9f0a6f10" >> $logfile
+./tcls_tx2txt.sh -vv -t c49b3c445c89d832289de0fd3b0281efdcce418333dacd028061e8de9f0a6f10 > tmpfile
+chksum_ref="3cf1e5460995e9eda70b613007116b63db132cb48afe58c3a3cb3a55bb7ab961"
+chksum_prep
+
+echo "=== TESTCASE 12d: a NullData (OP_RETURN) tx_out script:" | tee -a $logfile
+echo "https://blockexplorer.com/api/rawtx/d29c9c0e8e4d2a9790922af73f0b8d51f0bd4bb19940d9cf910ead8fbe85bc9b" >> $logfile
+echo "./tcls_tx2txt.sh -vv -r 01000000016ca9aad181967df29c02384f867ea09b90c41d7cee160bbd857d6a7520f45cb4000000006a473044022062ee7002c5483545b81623495e2fd04691fb7685dbc5251bff7581585037822502203df73a07c242cf0fa1611e4d99604801bf75a93c2fb02ac3defef4c369ea5f040121024ee119308c8a6f8a498e1b34bc9b73d91750a9eb4e749b3f45b34ea58f57de01ffffffff010000000000000000fddb036a4dd7035765277265206e6f20737472616e6765727320746f206c6f76650a596f75206b6e6f77207468652072756c657320616e6420736f20646f20490a412066756c6c20636f6d6d69746d656e74277320776861742049276d207468696e6b696e67206f660a596f7520776f756c646e27742067657420746869732066726f6d20616e79206f74686572206775790a49206a7573742077616e6e612074656c6c20796f7520686f772049276d206665656c696e670a476f747461206d616b6520796f7520756e6465727374616e640a0a43484f5255530a4e6576657220676f6e6e61206769766520796f752075702c0a4e6576657220676f6e6e61206c657420796f7520646f776e0a4e6576657220676f6e6e612072756e2061726f756e6420616e642064657365727420796f750a4e6576657220676f6e6e61206d616b6520796f75206372792c0a4e6576657220676f6e6e612073617920676f6f646279650a4e6576657220676f6e6e612074656c6c2061206c696520616e64206875727420796f750a0a5765277665206b6e6f776e2065616368206f7468657220666f7220736f206c6f6e670a596f75722068656172742773206265656e20616368696e672062757420796f7527726520746f6f2073687920746f207361792069740a496e7369646520776520626f7468206b6e6f7720776861742773206265656e20676f696e67206f6e0a5765206b6e6f77207468652067616d6520616e6420776527726520676f6e6e6120706c61792069740a416e6420696620796f752061736b206d6520686f772049276d206665656c696e670a446f6e27742074656c6c206d6520796f7527726520746f6f20626c696e6420746f20736565202843484f525553290a0a43484f52555343484f5255530a284f6f68206769766520796f75207570290a284f6f68206769766520796f75207570290a284f6f6829206e6576657220676f6e6e6120676976652c206e6576657220676f6e6e6120676976650a286769766520796f75207570290a284f6f6829206e6576657220676f6e6e6120676976652c206e6576657220676f6e6e6120676976650a286769766520796f75207570290a0a5765277665206b6e6f776e2065616368206f7468657220666f7220736f206c6f6e670a596f75722068656172742773206265656e20616368696e672062757420796f7527726520746f6f2073687920746f207361792069740a496e7369646520776520626f7468206b6e6f7720776861742773206265656e20676f696e67206f6e0a5765206b6e6f77207468652067616d6520616e6420776527726520676f6e6e6120706c61792069742028544f2046524f4e54290a0a00000000" >> $logfile
+./tcls_tx2txt.sh -vv -r 01000000016ca9aad181967df29c02384f867ea09b90c41d7cee160bbd857d6a7520f45cb4000000006a473044022062ee7002c5483545b81623495e2fd04691fb7685dbc5251bff7581585037822502203df73a07c242cf0fa1611e4d99604801bf75a93c2fb02ac3defef4c369ea5f040121024ee119308c8a6f8a498e1b34bc9b73d91750a9eb4e749b3f45b34ea58f57de01ffffffff010000000000000000fddb036a4dd7035765277265206e6f20737472616e6765727320746f206c6f76650a596f75206b6e6f77207468652072756c657320616e6420736f20646f20490a412066756c6c20636f6d6d69746d656e74277320776861742049276d207468696e6b696e67206f660a596f7520776f756c646e27742067657420746869732066726f6d20616e79206f74686572206775790a49206a7573742077616e6e612074656c6c20796f7520686f772049276d206665656c696e670a476f747461206d616b6520796f7520756e6465727374616e640a0a43484f5255530a4e6576657220676f6e6e61206769766520796f752075702c0a4e6576657220676f6e6e61206c657420796f7520646f776e0a4e6576657220676f6e6e612072756e2061726f756e6420616e642064657365727420796f750a4e6576657220676f6e6e61206d616b6520796f75206372792c0a4e6576657220676f6e6e612073617920676f6f646279650a4e6576657220676f6e6e612074656c6c2061206c696520616e64206875727420796f750a0a5765277665206b6e6f776e2065616368206f7468657220666f7220736f206c6f6e670a596f75722068656172742773206265656e20616368696e672062757420796f7527726520746f6f2073687920746f207361792069740a496e7369646520776520626f7468206b6e6f7720776861742773206265656e20676f696e67206f6e0a5765206b6e6f77207468652067616d6520616e6420776527726520676f6e6e6120706c61792069740a416e6420696620796f752061736b206d6520686f772049276d206665656c696e670a446f6e27742074656c6c206d6520796f7527726520746f6f20626c696e6420746f20736565202843484f525553290a0a43484f52555343484f5255530a284f6f68206769766520796f75207570290a284f6f68206769766520796f75207570290a284f6f6829206e6576657220676f6e6e6120676976652c206e6576657220676f6e6e6120676976650a286769766520796f75207570290a284f6f6829206e6576657220676f6e6e6120676976652c206e6576657220676f6e6e6120676976650a286769766520796f75207570290a0a5765277665206b6e6f776e2065616368206f7468657220666f7220736f206c6f6e670a596f75722068656172742773206265656e20616368696e672062757420796f7527726520746f6f2073687920746f207361792069740a496e7369646520776520626f7468206b6e6f7720776861742773206265656e20676f696e67206f6e0a5765206b6e6f77207468652067616d6520616e6420776527726520676f6e6e6120706c61792069742028544f2046524f4e54290a0a00000000 > tmpfile
+chksum_ref="2c61205a17d98196d6f5898d928aea7f2f841c78777b25543a8c12cfad3b44f5"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+
+testcase13() {
+# this trx has a complicated input script (PK script?)
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 13:                                          ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "===  this trx has 35 output scripts ...                   ===" >> $logfile
+echo "=============================================================" >> $logfile
+echo "https://blockchain.info/de/rawtx/7c83fe5ba301e655973e9de8eb9fb5e20ef3a6dd9b46c503679c858399eda50f" >> $logfile
+
+echo "=== TESTCASE 13a: 35 outputs" | tee -a $logfile
+  ./tcls_tx2txt.sh -r 01000000014675ab74e5c496c8eecaaa87c6136bc68ebaaac7a25e70ee29b7bbaffad6810f000000008b4830450220296d4f4869a63efdee4c5ea31dcad559b4e03332462ba5442bfdf00a662cb77102210088a7f10361eae3e159ae6a8b5b7a569bf6bfa2de64fb3f5d0552f8be568ba6f50141042a9a97b2109ef496ffb1033576a5635cecc6ab679ad0b7c43d33ddf38b1f44c22ea42d5c01ac2752094ff81e79dda77d8b501a64102207c45fb89ea1ad9229ddffffffff23e8030000000000001976a914801314cd462b98c64dd4c3f4d6474cad11ea39d588ace8030000000000001976a9145bb7d22851413e1d61e8db5395a8c7c537256ea088ace8030000000000001976a914371f197d5ba5e32bd98260eec7f0e51227b6969088ace8030000000000001976a9143e546d0acc0de5aa3d66d7a920900ecbc66c203188ace8030000000000001976a9140337e0710056f114c9c469a68775498df9f9fa1688ace8030000000000001976a9149c628c82aa7b81da7c6a235049eb2979c4a65cfc88ace8030000000000001976a914cd1d7e863f891c493e093ada840ef5a67ad2d6cc88ace8030000000000001976a91476f074340381e6f8a40aec4a6e2d92485679412c88ace8030000000000001976a9140fb87a5071385b6976397d1c53ee16f09139a33488ace8030000000000001976a9143d37873ffd2964a1a4c8bade4852020ec5426d3688ace8030000000000001976a9145d14a857fce8da8edfb8f7d1c4bbc316622b722788ace8030000000000001976a9140a77fdb4cc81631b6ea2991ff60b47d57812d8e788ace8030000000000001976a91454514fe9251b5e381d13171cd6fca63f61d8b72688ace8030000000000001976a914cffe3e032a686cc3f2c9e417865afa8a52ed962b88ace8030000000000001976a914fd9dc3525076c1ffe9c33389ea157d07af2e41d488ace8030000000000001976a9143bedfe927d55a8c8adfe5e4b5dddd4ea3487b4c988ace8030000000000001976a914e49275e86ece605f271f26a9559520eb9c0ae8d888ace8030000000000001976a91469256ba90b0d7e406d86a51d343d157ff0aab7bd88ace8030000000000001976a9148ab0cb809cd893cb0cb16f647d024db94f09d76588ace8030000000000001976a9140688e383f02b528c92e25caae5785ffaa81a26aa88ace8030000000000001976a914d959be6c92037995558f43a55b1c271628f96e8d88ac8038f240000000001976a914d15e54e341d538ce3e9e7596e0dbcda8c12cc08988ace8030000000000001976a91495019a8168e8dcd2ef2d47ca57c1bf49358eb6fe88ace8030000000000001976a914caf67cfe28b511498b0d1792bedeec6b6e8a3c8d88ace8030000000000001976a914082a3adf4c8497fbd7d90f21cbec318b0dfdd2b288ace8030000000000001976a9144c53722fd5b0bc8a5b23ae4efc6233142b69d8ee88ace8030000000000001976a9146abd1edce61a7fdd2d134e8468560ecffb45334e88ace8030000000000001976a914dc3343b674cf2016b8968e6146ba5cc9228f14a488ace8030000000000001976a9145f395a91d07712604d7cd6fabd685b9bfd3900dd88ace8030000000000001976a914fc35239072cd5c19d9f761996951679fb03bb43188ace8030000000000001976a914b1ec1d5e0591abbbe3134c94c37e74d034b9312288ace8030000000000001976a9142d6351944aa38af6aa46d4a74cbb9016cf19ee7e88ace8030000000000001976a914879a49b3822806e0322565d457ce2b5989adaa6188ace8030000000000001976a9145ff26e3f8d542c5bb612e539649eaec0222afc3c88ace8030000000000001976a914105d54a4edcbe114a50bb01c79d230b7ed74a3e488ac00000000 > tmpfile
+chksum_ref="8e21e91c529b13c6bdb58849003ddd53f643ce8f114eb762e91f4b3d1f10d1ef"
+chksum_prep
+
+echo "=== TESTCASE 13b: 35 outputs, verbose" | tee -a $logfile
+  ./tcls_tx2txt.sh -v -r 01000000014675ab74e5c496c8eecaaa87c6136bc68ebaaac7a25e70ee29b7bbaffad6810f000000008b4830450220296d4f4869a63efdee4c5ea31dcad559b4e03332462ba5442bfdf00a662cb77102210088a7f10361eae3e159ae6a8b5b7a569bf6bfa2de64fb3f5d0552f8be568ba6f50141042a9a97b2109ef496ffb1033576a5635cecc6ab679ad0b7c43d33ddf38b1f44c22ea42d5c01ac2752094ff81e79dda77d8b501a64102207c45fb89ea1ad9229ddffffffff23e8030000000000001976a914801314cd462b98c64dd4c3f4d6474cad11ea39d588ace8030000000000001976a9145bb7d22851413e1d61e8db5395a8c7c537256ea088ace8030000000000001976a914371f197d5ba5e32bd98260eec7f0e51227b6969088ace8030000000000001976a9143e546d0acc0de5aa3d66d7a920900ecbc66c203188ace8030000000000001976a9140337e0710056f114c9c469a68775498df9f9fa1688ace8030000000000001976a9149c628c82aa7b81da7c6a235049eb2979c4a65cfc88ace8030000000000001976a914cd1d7e863f891c493e093ada840ef5a67ad2d6cc88ace8030000000000001976a91476f074340381e6f8a40aec4a6e2d92485679412c88ace8030000000000001976a9140fb87a5071385b6976397d1c53ee16f09139a33488ace8030000000000001976a9143d37873ffd2964a1a4c8bade4852020ec5426d3688ace8030000000000001976a9145d14a857fce8da8edfb8f7d1c4bbc316622b722788ace8030000000000001976a9140a77fdb4cc81631b6ea2991ff60b47d57812d8e788ace8030000000000001976a91454514fe9251b5e381d13171cd6fca63f61d8b72688ace8030000000000001976a914cffe3e032a686cc3f2c9e417865afa8a52ed962b88ace8030000000000001976a914fd9dc3525076c1ffe9c33389ea157d07af2e41d488ace8030000000000001976a9143bedfe927d55a8c8adfe5e4b5dddd4ea3487b4c988ace8030000000000001976a914e49275e86ece605f271f26a9559520eb9c0ae8d888ace8030000000000001976a91469256ba90b0d7e406d86a51d343d157ff0aab7bd88ace8030000000000001976a9148ab0cb809cd893cb0cb16f647d024db94f09d76588ace8030000000000001976a9140688e383f02b528c92e25caae5785ffaa81a26aa88ace8030000000000001976a914d959be6c92037995558f43a55b1c271628f96e8d88ac8038f240000000001976a914d15e54e341d538ce3e9e7596e0dbcda8c12cc08988ace8030000000000001976a91495019a8168e8dcd2ef2d47ca57c1bf49358eb6fe88ace8030000000000001976a914caf67cfe28b511498b0d1792bedeec6b6e8a3c8d88ace8030000000000001976a914082a3adf4c8497fbd7d90f21cbec318b0dfdd2b288ace8030000000000001976a9144c53722fd5b0bc8a5b23ae4efc6233142b69d8ee88ace8030000000000001976a9146abd1edce61a7fdd2d134e8468560ecffb45334e88ace8030000000000001976a914dc3343b674cf2016b8968e6146ba5cc9228f14a488ace8030000000000001976a9145f395a91d07712604d7cd6fabd685b9bfd3900dd88ace8030000000000001976a914fc35239072cd5c19d9f761996951679fb03bb43188ace8030000000000001976a914b1ec1d5e0591abbbe3134c94c37e74d034b9312288ace8030000000000001976a9142d6351944aa38af6aa46d4a74cbb9016cf19ee7e88ace8030000000000001976a914879a49b3822806e0322565d457ce2b5989adaa6188ace8030000000000001976a9145ff26e3f8d542c5bb612e539649eaec0222afc3c88ace8030000000000001976a914105d54a4edcbe114a50bb01c79d230b7ed74a3e488ac00000000 > tmpfile
+chksum_ref="38e36b1fe565e36e2afbb13568a8b78e06d58a05e453bdea2c1c206438200ecd"
+chksum_prep
+
+echo "=== TESTCASE 13c: 35 outputs, very verbose" | tee -a $logfile
+  ./tcls_tx2txt.sh -vv -r 01000000014675ab74e5c496c8eecaaa87c6136bc68ebaaac7a25e70ee29b7bbaffad6810f000000008b4830450220296d4f4869a63efdee4c5ea31dcad559b4e03332462ba5442bfdf00a662cb77102210088a7f10361eae3e159ae6a8b5b7a569bf6bfa2de64fb3f5d0552f8be568ba6f50141042a9a97b2109ef496ffb1033576a5635cecc6ab679ad0b7c43d33ddf38b1f44c22ea42d5c01ac2752094ff81e79dda77d8b501a64102207c45fb89ea1ad9229ddffffffff23e8030000000000001976a914801314cd462b98c64dd4c3f4d6474cad11ea39d588ace8030000000000001976a9145bb7d22851413e1d61e8db5395a8c7c537256ea088ace8030000000000001976a914371f197d5ba5e32bd98260eec7f0e51227b6969088ace8030000000000001976a9143e546d0acc0de5aa3d66d7a920900ecbc66c203188ace8030000000000001976a9140337e0710056f114c9c469a68775498df9f9fa1688ace8030000000000001976a9149c628c82aa7b81da7c6a235049eb2979c4a65cfc88ace8030000000000001976a914cd1d7e863f891c493e093ada840ef5a67ad2d6cc88ace8030000000000001976a91476f074340381e6f8a40aec4a6e2d92485679412c88ace8030000000000001976a9140fb87a5071385b6976397d1c53ee16f09139a33488ace8030000000000001976a9143d37873ffd2964a1a4c8bade4852020ec5426d3688ace8030000000000001976a9145d14a857fce8da8edfb8f7d1c4bbc316622b722788ace8030000000000001976a9140a77fdb4cc81631b6ea2991ff60b47d57812d8e788ace8030000000000001976a91454514fe9251b5e381d13171cd6fca63f61d8b72688ace8030000000000001976a914cffe3e032a686cc3f2c9e417865afa8a52ed962b88ace8030000000000001976a914fd9dc3525076c1ffe9c33389ea157d07af2e41d488ace8030000000000001976a9143bedfe927d55a8c8adfe5e4b5dddd4ea3487b4c988ace8030000000000001976a914e49275e86ece605f271f26a9559520eb9c0ae8d888ace8030000000000001976a91469256ba90b0d7e406d86a51d343d157ff0aab7bd88ace8030000000000001976a9148ab0cb809cd893cb0cb16f647d024db94f09d76588ace8030000000000001976a9140688e383f02b528c92e25caae5785ffaa81a26aa88ace8030000000000001976a914d959be6c92037995558f43a55b1c271628f96e8d88ac8038f240000000001976a914d15e54e341d538ce3e9e7596e0dbcda8c12cc08988ace8030000000000001976a91495019a8168e8dcd2ef2d47ca57c1bf49358eb6fe88ace8030000000000001976a914caf67cfe28b511498b0d1792bedeec6b6e8a3c8d88ace8030000000000001976a914082a3adf4c8497fbd7d90f21cbec318b0dfdd2b288ace8030000000000001976a9144c53722fd5b0bc8a5b23ae4efc6233142b69d8ee88ace8030000000000001976a9146abd1edce61a7fdd2d134e8468560ecffb45334e88ace8030000000000001976a914dc3343b674cf2016b8968e6146ba5cc9228f14a488ace8030000000000001976a9145f395a91d07712604d7cd6fabd685b9bfd3900dd88ace8030000000000001976a914fc35239072cd5c19d9f761996951679fb03bb43188ace8030000000000001976a914b1ec1d5e0591abbbe3134c94c37e74d034b9312288ace8030000000000001976a9142d6351944aa38af6aa46d4a74cbb9016cf19ee7e88ace8030000000000001976a914879a49b3822806e0322565d457ce2b5989adaa6188ace8030000000000001976a9145ff26e3f8d542c5bb612e539649eaec0222afc3c88ace8030000000000001976a914105d54a4edcbe114a50bb01c79d230b7ed74a3e488ac00000000 > tmpfile
+chksum_ref="8e667119687edc2522301358c09154245110928788baea326915b8a579dedbe6"
+chksum_prep
+echo " " | tee -a $logfile
+}
+
+testcase14() {
+# this trx has a complicated input script (PK script?)
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 14:                                          ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "===  working with the TESTNET                             ===" >> $logfile
+echo "=============================================================" >> $logfile
+echo "=== TESTCASE 14a: TESTNET addresses" | tee -a $logfile
+
+./tcls_tx2txt.sh -T -vv -r 0100000001fc93e12cfbabe8383eba3c8c22d26c8ee941e9d1d98da0cf4f213e62e1ead47500000000fdfd0000473044022041ffcc40daaa2376a505132c63a1df4ea636650facbc870df460625c0661c62802202a03ac32d8bd8c67474c522245a06a79ced9e326e1266b914d2bcacaaa24860e01483045022100ffb0117cf0e8d0d0689f5adf6c5006212728901c07405dfa0cafcc42c9cbe7d6022044d168e217dc50f148ae3aee632e246554d2f9b57b53a2f18e8a68a3036e5a78014c69522103834bd129bf0a2e03d53b74bc2eef8d9a5faed93f37b4938ae7127d430804a3cf2103fae2fa202fbfd9d0a8650f537df154158761ce9ad2460793aed74b946babb9f421038cbc733032dcbed878c727840bef9c2aeb01447e1701c372c46a2ef00f48e02c53aeffffffff01638e582e000000001976a914431c4b76510347bb5f12907a819365f5e2834a1188ac00000000 > tmpfile
+chksum_ref="8a7e94a4cc51d8f91b1a87b1c0162ba4119ef5605f6912e4b78a9c50d5ff4be3"
+chksum_prep
+echo " " | tee -a $logfile
+} 
+
+testcase20() {
+# this trx has +50 P2SH signatures and takes a long time to decode
+echo "=============================================================" | tee -a $logfile
+echo "=== TESTCASE 20: check very long tx                       ===" | tee -a $logfile
+echo "=============================================================" | tee -a $logfile
+echo "=== trx 20a has +117 txin                                 ===" >> $logfile
+echo "=== trx 20a has +50 P2SH signatures                       ===" >> $logfile
+echo "=============================================================" >> $logfile
+echo "=== TESTCASE 20a: +117 txin ... " | tee -a $logfile
+./tcls_tx2txt.sh -vv -t 19312fd6b177257bbc90187040066c3b1e2a398dfa953658d5d068f2119ad45f > tmpfile
+chksum_ref="0d596da80b23c0f9db53ee1ab7fb7e28938be8cd6526598caaa8797fb58707a8"
+chksum_prep
+
+echo "=== TESTCASE 20b: +50 P2SH addresses" | tee -a $logfile
+./tcls_tx2txt.sh -vv -t 1a96838d65a724bee4addcd74b5cef8102fa6e4f5058f73f53c8134021db407a > tmpfile
+chksum_ref="0d596da80b23c0f9db53ee1ab7fb7e28938be8cd6526598caaa8797fb58707a8"
+chksum_prep
+echo " " | tee -a $logfile
+} 
+
+all_testcases() {
+  testcase1 
+  testcase2 
+  testcase3 
+  testcase4 
+  testcase5 
+  testcase6 
+  testcase7 
+  testcase8 
+  testcase9 
+  testcase10
+  testcase11
+  testcase12
+  testcase13
+  testcase14
+}
+
+#####################
+### here we start ###
+#####################
+logfile=$0.log
+if [ -f "$logfile" ] ; then rm $logfile; fi
+echo $date > $logfile
+
+###################################################################
+# verify our operating system, cause checksum commands differ ... #
+###################################################################
+OS=$(uname) 
+if [ OS="OpenBSD" ] ; then
+  chksum_cmd=sha256
+fi
+if [ OS="Linux" ] ; then
+  chksum_cmd="openssl sha256"
+fi
+if [ OS="Darwin" ] ; then
+  chksum_cmd="openssl sha256"
+fi
+
+################################
+# command line params handling #
+################################
+
+if [ $# -eq 0 ] ; then
+  all_testcases
+fi
+
+while [ $# -ge 1 ] 
+ do
+  case "$1" in
+  -h)
+     echo "usage: trx_testcases.sh -h|-l [1-9]"
+     echo "  "
+     echo "script does several testcases, mostly with checksums for verification"
+     echo "  "
+     exit 0
+     ;;
+  -l)
+     LOG=1
+     shift
+     if [ $# -eq 0 ] ; then
+       all_testcases
+     fi
+     ;;
+  1|2|3|4|5|6|7|8|9|10|11|12|13|14|20)
+     testcase$1 
+     shift
+     ;;
+  *)
+     echo "unknown parameter(s), try -h, exiting gracefully ..."
+     exit 0
+     ;;
+  esac
+done
+
+# clean up
+for i in tmp*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *hex; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *pem; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+

--- a/tcls_testcases_verify.sh
+++ b/tcls_testcases_verify.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+# some testcases for the shell script "tx_verify_sig.sh" 
+#
+# Copyright (c) 2015, 2016 Volker Nowarra 
+# initial release in Nov 2016
+# 
+# Permission to use, copy, modify, and distribute this software for any 
+# purpose with or without fee is hereby granted, provided that the above 
+# copyright notice and this permission notice appear in all copies. 
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY 
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER 
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE 
+# USE OR PERFORMANCE OF THIS SOFTWARE. 
+# 
+
+typeset -i LOG=0
+logfile=$0.log
+
+chksum_verify() {
+if [ "$1" == "$2" ] ; then
+  echo "ok"
+else
+  echo $1 | tee -a $logfile
+  echo "*************** checksum  mismatch, ref is: ********************" | tee -a $logfile
+  echo $2 | tee -a $logfile
+  echo " " | tee -a $logfile
+fi
+}
+
+to_logfile() {
+  # echo $chksum_ref >> $logfile
+  cat tmp_tx_cfile >> $logfile
+  echo " " >> $logfile
+}
+
+chksum_prep() {
+result=$( $chksum_cmd tmp_tx_cfile | cut -d " " -f 2 )
+# echo $result | cut -d " " -f 2 >> $logfile
+chksum_verify "$result" "$chksum_ref" 
+if [ $LOG -eq 1 ] ; then to_logfile ; fi
+}
+
+testcase1() {
+# first get the checksums of all necessary files
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 1: get the checksums of all necessary files     ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+
+echo "=== TESTCASE 1a: $chksum_cmd tcls_verify_sig.sh" | tee -a $logfile
+cp tcls_verify_sig.sh tmp_tx_cfile
+chksum_ref="f1ab5339fc86de2d8cae89c54ffbc7fa148a0d2abce8ed43e29b619e7a909e5e" 
+chksum_prep
+
+echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
+cp tcls_key2pem.sh tmp_tx_cfile
+chksum_ref="736af2ceeb382639f271abfe8cde580ebce816b98ae149037a95a2268ba7d893" 
+chksum_prep
+
+echo "=== TESTCASE 1c: $chksum_cmd tcls_strict_sig_verify.sh" | tee -a $logfile
+cp tcls_strict_sig_verify.sh tmp_tx_cfile
+chksum_ref="f45f17eed63026710b9b238ab8315c1816ec779e44ea0726fa6633897ca2c1f5"
+chksum_prep
+
+echo "=== TESTCASE 1d: $chksum_cmd tcls_verify_hexkey.awk" | tee -a $logfile
+cp tcls_verify_hexkey.awk tmp_tx_cfile
+chksum_ref="055b79074a8f33d0aa9aa7634980d29f4e3eb0248a730ea784c7a88e64aa7cfd"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase2() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 2: parameters testing ...                       ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 2a: -d param too short...     "                      | tee -a $logfile
+echo "./tcls_verify_sig.sh -v -d 0123456789abcdef -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e" >> $logfile
+./tcls_verify_sig.sh -v -d 0123456789abcdef -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e > tmp_tx_cfile
+chksum_ref="0895db88502710dd7e1aa02f7042e3cdfc55cb9f9f260898da29e8dfa819613f"
+chksum_prep
+
+echo "=== TESTCASE 2b: -p param too short...     "                      | tee -a $logfile
+echo "./tcls_verify_sig.sh -v -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 0123456789abcdef -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e" >> $logfile
+./tcls_verify_sig.sh -v -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 0123456789abcdef -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e > tmp_tx_cfile
+chksum_ref="d39e403b67f013969bab2d50ebf2a0d6804084cb6318d769f249a412512c8be5"
+chksum_prep
+
+echo "=== TESTCASE 2c: -s param too short...     "                      | tee -a $logfile
+echo "./tcls_verify_sig.sh -v -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221000123456789abcdef" >> $logfile
+./tcls_verify_sig.sh -v -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221000123456789abcdef > tmp_tx_cfile
+chksum_ref="0e411e0df79fa23e4c504b112bcc0353b8f81dbcc95439459bed91daf5d4726b"
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase3() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3: the pizza transaction ...                    ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 3a: pizza, quiet operation..."                       | tee -a $logfile
+echo "http://bitcoin.stackexchange.com/questions/32305/how-does-the-ecdsa-verification-algorithm-work-during-transaction/32308#32308" >> $logfile
+echo "./tcls_verify_sig.sh -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e" >> $logfile
+./tcls_verify_sig.sh -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669  -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e > tmp_tx_cfile
+chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3"
+chksum_prep
+
+echo "=== TESTCASE 3b: pizza, be a bit more verbose..." | tee -a $logfile
+echo "./tcls_verify_sig.sh -v -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e" >> $logfile
+./tcls_verify_sig.sh -v -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669  -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e > tmp_tx_cfile 
+chksum_ref="1ef0a0bfa83dc0c003c2abbdcf3825da589dd15faa73612de2803a1c5ed6cf7f" 
+chksum_prep
+
+echo "=== TESTCASE 3c: pizza, be very verbose..." | tee -a $logfile
+echo "./tcls_verify_sig.sh -vv -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669 -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e" >> $logfile
+./tcls_verify_sig.sh -vv -d c2d48f45d7fbeff644ddb72b0f60df6c275f0943444d7df8cc851b3d55782669  -p 042e930f39ba62c6534ee98ed20ca98959d34aa9e057cda01cfd422c6bab3667b76426529382c23f42b9b08d7832d4fee1d6b437a8526e59667ce9c4e9dcebcabb -s 30450221009908144ca6539e09512b9295c8a27050d478fbb96f8addbc3d075544dc41328702201aa528be2b907d316d2da068dd9eb1e23243d97e444d59290d2fddf25269ee0e > tmp_tx_cfile 
+chksum_ref="ffe4e1ccad6b88ec4afa7b777e82803591beedaa3dbc6092613e0043b618374a" 
+chksum_prep
+
+echo " " | tee -a $logfile
+}
+
+testcase4() {
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 4: use quiet mode to check all 4 sigs ...       ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "TX_IN[0]" >> $logfile
+echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304502210086199572c8e5879fa610bd244c7b2d054c389ed8b023f0a3d11f25606773e3f5022037086414c32a875fc2d43ec30664edbce447836e25f68ec39a3d04fd03590b57 -d 6f13d86405f2672b98d52e9d5244e133244885c4ce0d4f9087da9433a09f914f" >> $logfile
+./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304502210086199572c8e5879fa610bd244c7b2d054c389ed8b023f0a3d11f25606773e3f5022037086414c32a875fc2d43ec30664edbce447836e25f68ec39a3d04fd03590b57 -d 6f13d86405f2672b98d52e9d5244e133244885c4ce0d4f9087da9433a09f914f > tmp_tx_cfile
+chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
+chksum_prep
+
+echo "TX_IN[1]" >> $logfile
+echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022069f4f02bd808eb5381a8bc5b6e3a18219089f83b10b25277345439c52dfb42e30220107a09ad1aff0e20fd5c07b71d536943d72ca15c6e86f77282fe75478a64a466 -d e09e861272e2377a4528fbe28d1ee764706ca4b829aad7e08f4a0325e25c9053" >> $logfile
+./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022069f4f02bd808eb5381a8bc5b6e3a18219089f83b10b25277345439c52dfb42e30220107a09ad1aff0e20fd5c07b71d536943d72ca15c6e86f77282fe75478a64a466 -d e09e861272e2377a4528fbe28d1ee764706ca4b829aad7e08f4a0325e25c9053 > tmp_tx_cfile
+chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
+chksum_prep
+
+echo "TX_IN[2]" >> $logfile
+echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022058c884db944e2265f013493d98a56c958a86aeacc6655473a8cf477fac31f375022026b5915ed26e0149effac955ac30ba90ca25919072ab5a20a161575a55a8bc30 -d c5bfe4a6c58fb2e0398006b4109cdea737eb1413a127c5e61039a8858367750b" >> $logfile
+./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022058c884db944e2265f013493d98a56c958a86aeacc6655473a8cf477fac31f375022026b5915ed26e0149effac955ac30ba90ca25919072ab5a20a161575a55a8bc30 -d c5bfe4a6c58fb2e0398006b4109cdea737eb1413a127c5e61039a8858367750b > tmp_tx_cfile
+chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
+chksum_prep
+
+echo "TX_IN[3]" >> $logfile
+echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304402202adca291dd1c4058f124c01218e6d34e5a968de6fb932a4237fd33c5aa26930a0220493502e86bf6684593d5ea888f112503ed7ae054a1f4fa62d38df76898a6731e -d 64623a854acfc3e9ba5761a1209af9f3162d360b4eaff7f5c2d19010fa30f418" >> $logfile
+./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304402202adca291dd1c4058f124c01218e6d34e5a968de6fb932a4237fd33c5aa26930a0220493502e86bf6684593d5ea888f112503ed7ae054a1f4fa62d38df76898a6731e -d 64623a854acfc3e9ba5761a1209af9f3162d360b4eaff7f5c2d19010fa30f418 > tmp_tx_cfile
+chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
+chksum_prep
+
+echo "################################################" >> $logfile
+echo "### we cross check with openssl directly ... ###" >> $logfile
+echo "################################################" >> $logfile
+# The pubkey is: 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 
+echo 3036301006072a8648ce3d020106052b8104000a032200 > pubkey.txt
+echo 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 >> pubkey.txt
+xxd -r -p <pubkey.txt | openssl pkey -pubin -inform der >pubkey.pem
+
+# TX_IN[0], double sha256 and signature:   
+echo "TX_IN[0]:" >> $logfile
+echo 6f13d86405f2672b98d52e9d5244e133244885c4ce0d4f9087da9433a09f914f > tx_hash.txt
+echo 304502210086199572c8e5879fa610bd244c7b2d054c389ed8b023f0a3d11f25606773e3f5022037086414c32a875fc2d43ec30664edbce447836e25f68ec39a3d04fd03590b57 > tx_sig.txt
+xxd -r -p <tx_hash.txt >tx_hash.hex
+xxd -r -p <tx_sig.txt >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+ 
+# TX_IN[1], double sha256 and signature:
+echo "TX_IN[1]:" >> $logfile
+echo e09e861272e2377a4528fbe28d1ee764706ca4b829aad7e08f4a0325e25c9053 > tx_hash.txt
+echo 3044022069f4f02bd808eb5381a8bc5b6e3a18219089f83b10b25277345439c52dfb42e30220107a09ad1aff0e20fd5c07b71d536943d72ca15c6e86f77282fe75478a64a466 > tx_sig.txt
+xxd -r -p <tx_hash.txt >tx_hash.hex
+xxd -r -p <tx_sig.txt >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+ 
+# TX_IN[2], double sha256 and signature:
+echo "TX_IN[2]:" >> $logfile
+echo c5bfe4a6c58fb2e0398006b4109cdea737eb1413a127c5e61039a8858367750b > tx_hash.txt
+echo 3044022058c884db944e2265f013493d98a56c958a86aeacc6655473a8cf477fac31f375022026b5915ed26e0149effac955ac30ba90ca25919072ab5a20a161575a55a8bc30 > tx_sig.txt
+xxd -r -p <tx_hash.txt >tx_hash.hex
+xxd -r -p <tx_sig.txt >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+ 
+# TX_IN[3], double sha256 and signature:
+echo "TX_IN[3]:" >> $logfile
+echo 64623a854acfc3e9ba5761a1209af9f3162d360b4eaff7f5c2d19010fa30f418 > tx_hash.txt
+echo 304402202adca291dd1c4058f124c01218e6d34e5a968de6fb932a4237fd33c5aa26930a0220493502e86bf6684593d5ea888f112503ed7ae054a1f4fa62d38df76898a6731e > tx_sig.txt
+xxd -r -p <tx_hash.txt >tx_hash.hex
+xxd -r -p <tx_sig.txt >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+ 
+echo " " | tee -a $logfile
+}
+
+
+
+all_testcases() {
+  testcase1 
+  testcase2 
+  testcase3 
+  testcase4 
+}
+
+#####################
+### here we start ###
+#####################
+logfile=$0.log
+if [ -f "$logfile" ] ; then rm $logfile; fi
+echo $date > $logfile
+
+###################################################################
+# verify our operating system, cause checksum commands differ ... #
+###################################################################
+OS=$(uname) 
+if [ OS="OpenBSD" ] ; then
+  chksum_cmd=sha256
+fi
+if [ OS="Linux" ] ; then
+  chksum_cmd="openssl sha256"
+fi
+if [ OS="Darwin" ] ; then
+  chksum_cmd="openssl dgst -sha256"
+fi
+
+################################
+# command line params handling #
+################################
+
+if [ $# -eq 0 ] ; then
+  all_testcases
+fi
+
+if [ $# -eq 1 ] && [ "$1" == "-l" ] ; then
+  LOG=1
+  shift
+  all_testcases
+fi
+
+while [ $# -ge 1 ] 
+ do
+  case "$1" in
+  -h)
+     echo "usage: $0 -h|-l [1-9]"
+     echo "  "
+     echo "script does several testcases, mostly with checksums for verification"
+     echo "  "
+     exit 0
+     ;;
+  -l)
+     LOG=1
+     shift
+     ;;
+  1|2|3|4|5|6|7|8|9)
+     testcase$1 
+     shift
+     ;;
+  *)
+     echo "unknown parameter(s), try -h, exiting gracefully ..."
+     exit 0
+     ;;
+  esac
+done
+
+# clean up
+for i in tmp*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in *hex; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in p*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done
+for i in tx*; do
+  if [ -f "$i" ]; then rm $i ; fi
+done

--- a/tcls_tx2txt.sh
+++ b/tcls_tx2txt.sh
@@ -396,6 +396,10 @@ check_tool openssl
 check_tool sed
 check_tool tr
 
+echo "###################"
+echo "### so let's go ###"
+echo "###################"
+
 ###############################################
 ### Check if network is required and active ###
 ###############################################
@@ -452,8 +456,10 @@ if [ "$TX_id" ] ; then
   fi
 fi
 
+############################################
+### normalize tx and bring into an array ###
+############################################
 raw_TX=$( echo $raw_TX | tr [:lower:] [:upper:] )
-# bring the data in $raw_TX into an array 
 result=$( echo "$raw_TX" | sed 's/[[:xdigit:]]\{2\}/& /g' )
 if [ "$shell_string" == "bash" ] ; then
   # running this on OpenBSD creates errors, hence a for loop...
@@ -467,10 +473,6 @@ v_output "raw trx is this:"
 # v_output "number of tx_array elements: ${#tx_array[*]}, raw trx is this:"
 result=$( echo ${tx_array[*]} | tr -d " " )
 v_output "$result"
-
-echo "###################"
-echo "### so let's go ###"
-echo "###################"
 
 ##############################################################################
 ### STEP 1 - VERSION (4 Bytes) - Transaction data format version           ###

--- a/todos.txt
+++ b/todos.txt
@@ -45,10 +45,8 @@ SIG_MAX_LENGTH_CHARS=146
 I27: 25Oct2016, svn:
 ====================
 trx_sign.sh: 
-STEP 5:  need to do a var_int check here ...
-STEP 8:  need to do a var_int check here ...
 STEP 17: when there is a trx with multiple output, need to create a loop
-
+---> this can be closed, see item #52
 
 I33: 05Nov2016, svn:
 ====================
@@ -80,11 +78,6 @@ Compressed form of above needs to start with 0x02:
   02:d5:a7:69:89:89:7e:e6:72:fd:4a:2f:20:88:c7:
   a2:fd:ab:eb:a4:79:01:e5:48:b4:74:cb:0a:df:af:
   06:46:51
-
-
-I34: 08Nov2016, svn:
-====================
-tcls_sign.sh (and others): TRX_IN[i] shall always start with "0", like in script trx_2txt.sh
 
 
 I38: 16nov2016, svn:
@@ -133,7 +126,7 @@ I41: 14dec2016, svn:
 ====================
 tcls_*.sh:
 it is generally not a good idea, to have capital letters as variable names in shell scripts. They might interfere with shell variables! 
-Maybe rework all *.sh files - low priority…
+Maybe rework all *.sh files - low priority...
 
 
 I42: 16nov2016, svn:
@@ -201,6 +194,9 @@ TX malleability is something to be aware of though, it's what I lose sleep over 
 Your approach with get received by address is probably fine, keep us posted how it goes.
 Triggers: There are two options blocknotify and wallet notify I think it is. You can put a shell command as a parameter to invoke php, node or python script.
 
+---> no, for a webpage with an address it is better to use HD wallets: 
+Hierarchical Deterministic Wallets (BIP0032/BIP0044)
+
 
 I51: 02apr2017, svn:
 ====================
@@ -220,6 +216,25 @@ testcases_tcls_sign.sh:
 Testcase 10i (?) in testcases_tcls_create.sh shall be reflected in "tcls_sign.sh", with the same input values, and then signed. The example to compare is here:
     https://gist.githubusercontent.com/gavinandresen/3966071/raw/
     1f6cfa4208bc82ee5039876b4f065a705ce64df7/TwoOfThree.sh
+
+
+
+I56: 23jun2017, svn:
+====================
+tcls_sign.sh: when a tx has more than 100 utxo, the signing process creates an error roughly every 2nd attempt. Looks like this happens for signatures, where a new S-Value must be calculated. The new S-value should be less then N/2. The system creates a new S value, but it's length is then 63 bytes, instead of 64 bytes.
+
+
+I57: 27jun2017, svn:
+====================
+OpenBSD and ./tcls_testcases_verify.sh
+TESTCASE 4:
+./tcls_testcases_verify.sh[234]: xxd: not found
+unable to load Public Key
+./tcls_testcases_verify.sh[234]: xxd: not found
+./tcls_testcases_verify.sh[234]: xxd: not found
+unable to load Public Key
+Error initializing context
+
 
 
 #####################################


### PR DESCRIPTION
when signing tx with more than 25tx, the tools like 'cut' and 'tr' stopped working, cause they reached their buffer limit (2048 chars on OpenBSD). So conversion of all data into an array (similiar like already done on tcls_tx2txt.sh). Minor chnages to the acompanying scripts...