### PR TITLE
uploaded all files changed last 3 days

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -38,4 +38,4 @@ yymmmdd
 17aug22 svn   tcls_tx2txt.sh         I67b SegWIT fixed ...
 17Sep27 svn   tcls_tx2txt.sh         I71 fix issues with sequence numbers not being FFFFFFFF
 17Oct29 svn   tcls_in_sig_script.sh  I69 get OpCodes correctly displayed (smart comtracts!)
-
+17nov01 svn   all files ...          I51, I57, I72: Replace "xxd" and improve code

--- a/tcls_base58check_enc.sh
+++ b/tcls_base58check_enc.sh
@@ -184,6 +184,7 @@ if [ $ECDSA_PK -eq 1 ] ; then
   v_output "2. SHA256 hash of public ECDSA key"
   tmpvar=$( echo $param | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
   result=$( printf "$tmpvar" | openssl dgst -sha256 | cut -d " " -f 2 )
+
   v_output "   $result"
   ##############################################
   ### 3: do ripemd160 on sha of ECDSA pubkey ###

--- a/tcls_sign.sh
+++ b/tcls_sign.sh
@@ -674,9 +674,10 @@ while [ $j -le $TX_IN_Count_dec ]
   fi
 
   # Bitcoin never does sha256 with the hex chars, so need to convert it to hex codes first
-  cat $utxhex_tmp_fn | tr [:upper:] [:lower:] > $utxtxt_tmp_fn
-  result=$( cat $utxtxt_tmp_fn | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
-  printf $result > $utxtxt_tmp_fn
+  # cat $utxhex_tmp_fn | tr [:upper:] [:lower:] > $utxtxt_tmp_fn
+  # result=$( cat $utxtxt_tmp_fn | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
+  # printf $result > $utxtxt_tmp_fn
+  printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <$utxhex_tmp_fn) > $utxtxt_tmp_fn
 
   openssl dgst -binary -sha256 >$utx_sha256_fn  <$utxtxt_tmp_fn 
   openssl dgst -binary -sha256 >$utx_dsha256_fn <$utx_sha256_fn 

--- a/tcls_testcases_sign.sh
+++ b/tcls_testcases_sign.sh
@@ -52,7 +52,7 @@ echo "================================================================" | tee -a
 
 echo "=== TESTCASE 1a: $chksum_cmd tcls_sign.sh" | tee -a $logfile
 cp tcls_sign.sh tmp_tx_cfile
-chksum_ref="b81b4698981a15a44b5f9cbbc1f15c783e0c74b275098e504764174b3dc9c862" 
+chksum_ref="65d00bde9c44a046bc07b30edc4dea4803528ba5025567535b3eb45d3dc9be7c" 
 chksum_prep
 
 echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile

--- a/tcls_testcases_tx2txt.sh
+++ b/tcls_testcases_tx2txt.sh
@@ -65,7 +65,7 @@ cp tcls_out_pk_script.sh tmpfile
 chksum_prep
 
 echo "=== TESTCASE 1d: $chksum_cmd tcls_base58check_enc.sh" | tee -a $logfile
-chksum_ref="cbc1ce97e94e22d70aba81145f0dda80d9495428317b675bf078e14e6bffd33e" 
+chksum_ref="5ec23ff90c5f5dadf03de6eb634c3d9babb7d376e1fd36ce03eff96f75810af0" 
 cp tcls_base58check_enc.sh tmpfile
 chksum_prep
 echo " " | tee -a $logfile
@@ -237,29 +237,30 @@ echo " " | tee -a $logfile
 
 testcase6() {
 echo "================================================================" | tee -a $logfile
-echo "=== TESTCASE 6: this trx has 1 input, and 4 outputs          ===" | tee -a $logfile
-echo "=== trx-in sequence = feffffff - what does this mean?        ===" >> $logfile
-echo "=== bitcoin.org: setting all sequence numbers to 0xffffffff  ===" >> $logfile
-echo "=== (the default in Bitcoin Core) can still disable the time ===" >> $logfile
-echo "=== lock, so if you want to use locktime, at least one input ===" >> $logfile
-echo "=== must have a sequence number below the the maximum.       ===" >> $logfile
+echo "=== TESTCASE 6: tx with several inputs and outputs           ===" | tee -a $logfile
 echo "================================================================" | tee -a $logfile
 echo "https://blockchain.info/de/rawtx/7264f8ba4a85a4780c549bf04a98e8de4c9cb1120cb1dfe8ab85ff6832eff864" >> $logfile
 
-echo "=== TESTCASE 6a: ./tcls_tx2txt.sh -r 0100000001df64d3e79..." | tee -a $logfile
+echo "=== TESTCASE 6a: 1 input, 4 outputs - non verbose..." | tee -a $logfile
 ./tcls_tx2txt.sh -r 0100000001df64d3e790779777de937eea18884e9b131c9910bdb860b1a5cea225b61e3510020000006b48304502210082e594fdd17f4f2995edc180e5373a664eb56f56420f0c8761a27fa612db2a2b02206bcd4763303661c9ccaac3e4e7f6bfc062f17ce4b6b1b479ee067a05e5a578b10121036932969ec8c5cecebc1ff6fc07126f8cb5589ada69db8ca97a4f1291ead8c06bfeffffff04d130ab00000000001976a9141f59b78ccc26b6d84a65b0d362185ac4683197ed88acf0fcf300000000001976a914f12d85961d3a36119c2eaed5ad0e728a789ab59c88acb70aa700000000001976a9142baaf47baf1bd1e3dad3956db536c3f2e87c237b88ac94804707000000001976a914cb1b1d3c8be7db6416c16a1d29db170930970a3088acce3d0600 > tmpfile
 chksum_ref="d73f48f73285db8e1d11331d7e3e0a6baada5b36718bf156f548bdcbfeb56da4"
 chksum_prep
 
-echo "=== TESTCASE 6b: ./tcls_tx2txt.sh -v -r 0100000001df64d3e79..." | tee -a $logfile
+echo "=== TESTCASE 6b: 1 input, 4 outputs - verbose..." | tee -a $logfile
 ./tcls_tx2txt.sh -v -r 0100000001df64d3e790779777de937eea18884e9b131c9910bdb860b1a5cea225b61e3510020000006b48304502210082e594fdd17f4f2995edc180e5373a664eb56f56420f0c8761a27fa612db2a2b02206bcd4763303661c9ccaac3e4e7f6bfc062f17ce4b6b1b479ee067a05e5a578b10121036932969ec8c5cecebc1ff6fc07126f8cb5589ada69db8ca97a4f1291ead8c06bfeffffff04d130ab00000000001976a9141f59b78ccc26b6d84a65b0d362185ac4683197ed88acf0fcf300000000001976a914f12d85961d3a36119c2eaed5ad0e728a789ab59c88acb70aa700000000001976a9142baaf47baf1bd1e3dad3956db536c3f2e87c237b88ac94804707000000001976a914cb1b1d3c8be7db6416c16a1d29db170930970a3088acce3d0600 > tmpfile
 chksum_ref="6d0e6d5de957435b784b396154da02f6c33fec4c18402ead23bfc50103cf12cc"
 chksum_prep
 
-echo "=== TESTCASE 6c: ./tcls_tx2txt.sh -vv -r 0100000001df64d3e79..." | tee -a $logfile
+echo "=== TESTCASE 6b: 1 input, 4 outputs - very verbose..." | tee -a $logfile
 ./tcls_tx2txt.sh -vv -r 0100000001df64d3e790779777de937eea18884e9b131c9910bdb860b1a5cea225b61e3510020000006b48304502210082e594fdd17f4f2995edc180e5373a664eb56f56420f0c8761a27fa612db2a2b02206bcd4763303661c9ccaac3e4e7f6bfc062f17ce4b6b1b479ee067a05e5a578b10121036932969ec8c5cecebc1ff6fc07126f8cb5589ada69db8ca97a4f1291ead8c06bfeffffff04d130ab00000000001976a9141f59b78ccc26b6d84a65b0d362185ac4683197ed88acf0fcf300000000001976a914f12d85961d3a36119c2eaed5ad0e728a789ab59c88acb70aa700000000001976a9142baaf47baf1bd1e3dad3956db536c3f2e87c237b88ac94804707000000001976a914cb1b1d3c8be7db6416c16a1d29db170930970a3088acce3d0600 > tmpfile
 chksum_ref="7f8605461c56157870282e501e73ea89dd79358f8a3be7c6eab19f3f21b7efbd"
 chksum_prep
+
+echo "=== TESTCASE 6d: 4 inputs, 2 outputs, very verbose..." | tee -a $logfile
+./tcls_tx2txt.sh -vv -r 01000000046c969e2396497561ebc6fc7cf845022e21b2ebf63e4a6d82544d521310cf3542040000006b483045022100d8cd1b4e6e0999ac397c8d78eae0520366f622be1b062db02479c0aa7f68dde2022070c8d5a4dd2a02b89ee5d4f3b0cf12a46e280dcc9fc405f9d042e93ad3cf20ea01210200a6d3e2a688e720955424cff5a359ee3db7185faad71d5fc8d9c85118dfbd07fffffffffd2dd2b83d84e8f7a076c09256ede7b4d39583da70d9fea181168f36a594b491000000006a473044022030a889577fd95a48ba39fc6f8b059c352fa96618b10b6e42861d23bff3a3300c0220194edb9655edc2a404131b85bb83e68a3acba8f9ebe8a752a58b028f157fca4c0121021093ead70ce7d56115851fb3ca16de1dd39478cdcf2264c94929eaf28571f029ffffffff9ede725ecef99fa5f0e059f26e2bb9f4d6c7783eba4a000e250bf48509820be3000000006a4730440220476940dd78a56e4b66476dd1038e4a305f72b63d21bdc52322e1766c2087341202203a24070a44417588e65e5da348c2b5f96a7efed05d2b28e7b932e76ccdd38d120121029912e17b6e5833d035967dc67b97ce51628a381e451aecfda3d40d679cd1af3fffffffff244887dd1af93418ac9cdda199ae77c557445f280ed91daa04326810bab51ef0010000006a47304402201b68ea684b2d7bd5bfed7f7de589f30253c40908d132f25e718b2f886b18a27f0220230c10572c131c27816c7f73e269bad3312eb737b090034c2e0a2a1c3d0cabb2012102b5e9cba15229ec36732f19fe271de7f8c36ff0901e0a45d3dab6faee6f2f1442ffffffff026f110100000000001976a914ac4aeeedc2a3f4331bc7b40e9e71aa65dcb6b93c88acb5e10e00000000001976a9145140c47d2e2821fd062a412e697e3d08723e71ed88ac00000000 > tmpfile
+chksum_ref="5c7b727115fdcd195e72ab3543cd929a17ffc6517b7fecad16b3c87d86a8db67"
+chksum_prep
+
 echo " " | tee -a $logfile
 }
 

--- a/tcls_testcases_verify.sh
+++ b/tcls_testcases_verify.sh
@@ -52,7 +52,7 @@ echo "================================================================" | tee -a
 
 echo "=== TESTCASE 1a: $chksum_cmd tcls_verify_sig.sh" | tee -a $logfile
 cp tcls_verify_sig.sh tmp_tx_cfile
-chksum_ref="f1ab5339fc86de2d8cae89c54ffbc7fa148a0d2abce8ed43e29b619e7a909e5e" 
+chksum_ref="2d4cfa45e5de065c3ab101265d0ffa000b43e29268c486ca8f1cd6cccee9e1c0" 
 chksum_prep
 
 echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
@@ -126,71 +126,72 @@ echo " " | tee -a $logfile
 
 testcase4() {
 echo "================================================================" | tee -a $logfile
-echo "=== TESTCASE 4: use quiet mode to check all 4 sigs ...       ===" | tee -a $logfile
+echo "=== TESTCASE 4: use quiet mode to check 4 sigs ...           ===" | tee -a $logfile
 echo "================================================================" | tee -a $logfile
-echo "TX_IN[0]" >> $logfile
+echo "=== TESTCASE 4a: ./tcls_verify_sig.sh -p p1 -s sig1 -d d1 " | tee -a $logfile
 echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304502210086199572c8e5879fa610bd244c7b2d054c389ed8b023f0a3d11f25606773e3f5022037086414c32a875fc2d43ec30664edbce447836e25f68ec39a3d04fd03590b57 -d 6f13d86405f2672b98d52e9d5244e133244885c4ce0d4f9087da9433a09f914f" >> $logfile
 ./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304502210086199572c8e5879fa610bd244c7b2d054c389ed8b023f0a3d11f25606773e3f5022037086414c32a875fc2d43ec30664edbce447836e25f68ec39a3d04fd03590b57 -d 6f13d86405f2672b98d52e9d5244e133244885c4ce0d4f9087da9433a09f914f > tmp_tx_cfile
 chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
 chksum_prep
 
-echo "TX_IN[1]" >> $logfile
+echo "=== TESTCASE 4b: ./tcls_verify_sig.sh -p p2 -s sig2 -d d2 " | tee -a $logfile
 echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022069f4f02bd808eb5381a8bc5b6e3a18219089f83b10b25277345439c52dfb42e30220107a09ad1aff0e20fd5c07b71d536943d72ca15c6e86f77282fe75478a64a466 -d e09e861272e2377a4528fbe28d1ee764706ca4b829aad7e08f4a0325e25c9053" >> $logfile
 ./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022069f4f02bd808eb5381a8bc5b6e3a18219089f83b10b25277345439c52dfb42e30220107a09ad1aff0e20fd5c07b71d536943d72ca15c6e86f77282fe75478a64a466 -d e09e861272e2377a4528fbe28d1ee764706ca4b829aad7e08f4a0325e25c9053 > tmp_tx_cfile
 chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
 chksum_prep
 
-echo "TX_IN[2]" >> $logfile
+echo "=== TESTCASE 4c: ./tcls_verify_sig.sh -p p3 -s sig3 -d d3 " | tee -a $logfile
 echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022058c884db944e2265f013493d98a56c958a86aeacc6655473a8cf477fac31f375022026b5915ed26e0149effac955ac30ba90ca25919072ab5a20a161575a55a8bc30 -d c5bfe4a6c58fb2e0398006b4109cdea737eb1413a127c5e61039a8858367750b" >> $logfile
 ./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 3044022058c884db944e2265f013493d98a56c958a86aeacc6655473a8cf477fac31f375022026b5915ed26e0149effac955ac30ba90ca25919072ab5a20a161575a55a8bc30 -d c5bfe4a6c58fb2e0398006b4109cdea737eb1413a127c5e61039a8858367750b > tmp_tx_cfile
 chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
 chksum_prep
 
-echo "TX_IN[3]" >> $logfile
+echo "=== TESTCASE 4d: ./tcls_verify_sig.sh -p p4 -s sig4 -d d4 " | tee -a $logfile
 echo "./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304402202adca291dd1c4058f124c01218e6d34e5a968de6fb932a4237fd33c5aa26930a0220493502e86bf6684593d5ea888f112503ed7ae054a1f4fa62d38df76898a6731e -d 64623a854acfc3e9ba5761a1209af9f3162d360b4eaff7f5c2d19010fa30f418" >> $logfile
 ./tcls_verify_sig.sh -p 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 -s 304402202adca291dd1c4058f124c01218e6d34e5a968de6fb932a4237fd33c5aa26930a0220493502e86bf6684593d5ea888f112503ed7ae054a1f4fa62d38df76898a6731e -d 64623a854acfc3e9ba5761a1209af9f3162d360b4eaff7f5c2d19010fa30f418 > tmp_tx_cfile
 chksum_ref="0bd65ea014d3210c1b9a7d7d5af78bc4e4b4384b4f3f7f5674e8d6447e4112c3" 
 chksum_prep
 
-echo "################################################" >> $logfile
-echo "### we cross check with openssl directly ... ###" >> $logfile
-echo "################################################" >> $logfile
+echo "######################################################" | tee -a $logfile
+echo "### we cross check with openssl directly           ###" | tee -a $logfile
+echo "### openssl pkeyutl <tx_hash.hex -verify -pubin    ###" | tee -a $logfile
+echo "###         -inkey pubkey.pem -sigfile tx_sig.hex  ###" | tee -a $logfile
+echo "######################################################" | tee -a $logfile
 # The pubkey is: 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 
-echo 3036301006072a8648ce3d020106052b8104000a032200 > pubkey.txt
-echo 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 >> pubkey.txt
-xxd -r -p <pubkey.txt | openssl pkey -pubin -inform der >pubkey.pem
+printf 3036301006072a8648ce3d020106052b8104000a032200 > pubkey.txt
+printf 03cc5debc62369bd861900b167bc6add5f1a6249bdab4146d5ce698879988dced0 >> pubkey.txt
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <pubkey.txt) | openssl pkey -pubin -inform der >pubkey.pem
 
-# TX_IN[0], double sha256 and signature:   
+echo "=== TESTCASE 4a: openssl pkeyutl ... " | tee -a $logfile
 echo "TX_IN[0]:" >> $logfile
 echo 6f13d86405f2672b98d52e9d5244e133244885c4ce0d4f9087da9433a09f914f > tx_hash.txt
 echo 304502210086199572c8e5879fa610bd244c7b2d054c389ed8b023f0a3d11f25606773e3f5022037086414c32a875fc2d43ec30664edbce447836e25f68ec39a3d04fd03590b57 > tx_sig.txt
-xxd -r -p <tx_hash.txt >tx_hash.hex
-xxd -r -p <tx_sig.txt >tx_sig.hex
-openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+# xxd -r -p <tx_hash.txt >tx_hash.hex
+# xxd -r -p <tx_sig.txt >tx_sig.hex
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_hash.txt) >tx_hash.hex
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_sig.txt) >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex  | tee -a $logfile
  
-# TX_IN[1], double sha256 and signature:
-echo "TX_IN[1]:" >> $logfile
+echo "=== TESTCASE 4b: openssl pkeyutl ... " | tee -a $logfile
 echo e09e861272e2377a4528fbe28d1ee764706ca4b829aad7e08f4a0325e25c9053 > tx_hash.txt
 echo 3044022069f4f02bd808eb5381a8bc5b6e3a18219089f83b10b25277345439c52dfb42e30220107a09ad1aff0e20fd5c07b71d536943d72ca15c6e86f77282fe75478a64a466 > tx_sig.txt
-xxd -r -p <tx_hash.txt >tx_hash.hex
-xxd -r -p <tx_sig.txt >tx_sig.hex
-openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_hash.txt) >tx_hash.hex
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_sig.txt) >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex  | tee -a $logfile
  
-# TX_IN[2], double sha256 and signature:
-echo "TX_IN[2]:" >> $logfile
+echo "=== TESTCASE 4c: openssl pkeyutl ... " | tee -a $logfile
 echo c5bfe4a6c58fb2e0398006b4109cdea737eb1413a127c5e61039a8858367750b > tx_hash.txt
 echo 3044022058c884db944e2265f013493d98a56c958a86aeacc6655473a8cf477fac31f375022026b5915ed26e0149effac955ac30ba90ca25919072ab5a20a161575a55a8bc30 > tx_sig.txt
-xxd -r -p <tx_hash.txt >tx_hash.hex
-xxd -r -p <tx_sig.txt >tx_sig.hex
-openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_hash.txt) >tx_hash.hex
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_sig.txt) >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex  | tee -a $logfile
  
-# TX_IN[3], double sha256 and signature:
-echo "TX_IN[3]:" >> $logfile
+echo "=== TESTCASE 4d: openssl pkeyutl ... " | tee -a $logfile
 echo 64623a854acfc3e9ba5761a1209af9f3162d360b4eaff7f5c2d19010fa30f418 > tx_hash.txt
 echo 304402202adca291dd1c4058f124c01218e6d34e5a968de6fb932a4237fd33c5aa26930a0220493502e86bf6684593d5ea888f112503ed7ae054a1f4fa62d38df76898a6731e > tx_sig.txt
-xxd -r -p <tx_hash.txt >tx_hash.hex
-xxd -r -p <tx_sig.txt >tx_sig.hex
-openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex >> $logfile
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_hash.txt) >tx_hash.hex
+printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <tx_sig.txt) >tx_sig.hex
+openssl pkeyutl <tx_hash.hex -verify -pubin -inkey pubkey.pem -sigfile tx_sig.hex  | tee -a $logfile
  
 echo " " | tee -a $logfile
 }

--- a/tcls_verify_sig.sh
+++ b/tcls_verify_sig.sh
@@ -302,8 +302,9 @@ if [ "$pubkey_1stchar" == "04" ] ; then
     data_show $pubkey
   fi
   echo $pre_pubstr_uc$pubkey > pubkey.hex
-  result=$( cat pubkey.hex | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
-  printf "$result" > tmp_key2pem
+  # result=$( cat pubkey.hex | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
+  # printf "$result" > tmp_key2pem
+  printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <pubkey.hex) > tmp_key2pem
 else
   if [ $VVerbose -eq 1 ] ; then
     echo "    a pre_pubstr:"
@@ -312,8 +313,9 @@ else
     data_show $pubkey
   fi
   echo $pre_pubstr_c$pubkey > pubkey.hex
-  result=$( cat pubkey.hex | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
-  printf "$result" > tmp_key2pem
+  # result=$( cat pubkey.hex | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
+  # printf "$result" > tmp_key2pem
+  printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' <pubkey.hex) > tmp_key2pem
 fi
 v_output  "    base64 pubkey.hex file and put some nice surroundings"
 vv_output "    openssl enc -base64 -in tmp_key2pem"

--- a/todos.txt
+++ b/todos.txt
@@ -216,7 +216,7 @@ q: how many public/private keypairs can a 24 word hierarchical deterministic wal
 a: 2^31, the number of words in the mnemonic has nothing to do with the capacity, it just adjusts the entropy for the key derivation
 
 
-I51: 02apr2017, svn:
+I51: 02apr2017, svn: - done
 ====================
 testcases_tcls_verify_sig.sh: on OpenBSD the testcase 4 fails ...
 
@@ -242,7 +242,7 @@ I56: 23jun2017, svn:
 tcls_sign.sh: when a tx has more than 100 utxo, the signing process creates an error roughly every 2nd attempt. Looks like this happens for signatures, where a new S-Value must be calculated. The new S-value should be less then N/2. The system creates a new S value, but it's length is then 63 bytes, instead of 64 bytes.
 
 
-I57: 27jun2017, svn:
+I57: 27jun2017, svn: - done
 ====================
 OpenBSD and ./tcls_testcases_verify.sh
 TESTCASE 4:
@@ -258,55 +258,6 @@ I58: 20jul2017, svn:
 ====================
 P2SH scripts - length limitations:
 https://bitcoin.stackexchange.com/questions/38937/what-was-the-original-rationale-for-limiting-the-maximum-push-size
-
-
-I59: Segwit :-) - Done
-===============
-https://bitcoincore.org/en/segwit_wallet_dev/
-integrate segwit into tcls_tx2txt.sh, e.g. this tx:
-https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
-Native P2WPKH:
-==============
-01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000
-which converts to:
-    nVersion:  01000000
-    marker:    00
-    flag:      01
-    txin:      02 fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f 00000000 494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01 eeffffff
-                  ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a 01000000 00 ffffffff
-    txout:     02 202cb20600000000 1976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac
-                  9093510d00000000 1976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac
-    witness    00
-               02 47304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee01 21025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357
-    nLockTime: 11000000
-
-
-on https://bitcointalk.org/index.php?topic=1398994.0;all:
-by: Achow101, March 16, 2016, 08:04:51 PM
-a normal client would see this tx as:
-0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac11000000
-
-
-P2SH-P2WPKH:
-============
-01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000001716001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000
-Native P2WSH:
-=============
-01000000000102fe3dc9208094f3ffd12645477b3dc56f60ec4fa8e6f5d67c565d1c6b9216b36e000000004847304402200af4e47c9b9629dbecc21f73af989bdaa911f7e6f6c2e9394588a3aa68f81e9902204f3fcf6ade7e5abb1295b6774c8e0abd94ae62217367096bc02ee5e435b67da201ffffffff0815cf020f013ed6cf91d29f4202e8a58726b1ac6c79da47c23d1bee0a6925f80000000000ffffffff0100f2052a010000001976a914a30741f8145e5acadf23f751864167f32e0963f788ac000347304402200de66acf4527789bfda55fc5459e214fa6083f936b430a762c629656216805ac0220396f550692cd347171cbc1ef1f51e15282e837bb2b30860dc77c8f78bc8501e503473044022027dc95ad6b740fe5129e7e62a75dd00f291a2aeb1200b84b09d9e3789406b6c002201a9ecd315dd6a0e632ab20bbb98948bc0c6fb204f2c286963bb48517a7058e27034721026dccc749adc2a9d0d89497ac511f760f45c47dc5ed9cf352a58ac706453880aeadab210255a9626aebf5e29c0e6538428ba0d1dcf6ca98ffdf086aa8ced5e0d0215ea465ac00000000
-P2SH-P2WSH 6-of-6 multisig witness:
-===================================
-0100000000010136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e0100000023220020a16b5755f7f6f96dbd65f5f0d6ab9418b89af4b1f14a1bb8a09062c35f0dcb54ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688acc0832f05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac080047304402206ac44d672dac41f9b00e28f4df20c52eeb087207e8d758d76d92c6fab3b73e2b0220367750dbbe19290069cba53d096f44530e4f98acaa594810388cf7409a1870ce01473044022068c7946a43232757cbdf9176f009a928e1cd9a1a8c212f15c1e11ac9f2925d9002205b75f937ff2f9f3c1246e547e54f62e027f64eefa2695578cc6432cdabce271502473044022059ebf56d98010a932cf8ecfec54c48e6139ed6adb0728c09cbe1e4fa0915302e022007cd986c8fa870ff5d2b3a89139c9fe7e499259875357e20fcbb15571c76795403483045022100fbefd94bd0a488d50b79102b5dad4ab6ced30c4069f1eaa69a4b5a763414067e02203156c6a5c9cf88f91265f5a942e96213afae16d83321c8b31bb342142a14d16381483045022100a5263ea0553ba89221984bd7f0b13613db16e7a70c549a86de0cc0444141a407022005c360ef0ae5a5d4f9f2f87a56c1546cc8268cab08c73501d6b3be2e1e1a8a08824730440220525406a1482936d5a21888260dc165497a90a15669636d8edca6b9fe490d309c022032af0c646a34a44d1f4576bf6a4a74b67940f8faa84c7df9abe12a01a11e2b4783cf56210307b8ae49ac90a048e9b53357a2354b3334e9c8bee813ecb98e99a7e07e8c3ba32103b28f0c28bfab54554ae8c658ac5c3e0ce6e79ad336331f78c428dd43eea8449b21034b8113d703413d57761b8b9781957b8c0ac1dfe69f492580ca4195f50376ba4a21033400f6afecb833092a9a21cfdf1ed1376e58c5d1f47de74683123987e967a8f42103a6d48b1131e94ba04d9737d61acdaa1322008af9602b3b14862c07a1789aac162102d8b661b0b3302ee2f162b09e07a55ad5dfbe673a9f01d9f0c19617681024306b56ae00000000
-
-or:
-0200000000010129b0f742d41c6aad58dd0e779ca53b8bed1790465ed59ed20d2b6a3ecc6744920100000000ffffffff0178cdf5050000000016001443aac20a116e09ea4f7914be1c55e4c17aa600b702483045022100e8877e9351abcfc5dc20a9c9f55d7bcde8d64993d135a20568b5b8628ea3f7b102203801629aad6a7ec0960b4d830aedac673d620179753cc6f197eaed866a4959ba012103335134d7414e1d1a154600b124a96f5ef2c6ca21434d2622469a96bd5262fd5600000000
-
-or:
-02000000021a81aa94d50686201482a7b286f9c8674139741660651b4cd5260ea5a360fdb8000000006a473044022063dc53dde52373c78ea8587b637b2ee6004a42cddbadd955122a8112dd08c89302206af141ce61d9d8ec4a2cce4e18ba0bf72af72d14de8a8219f79ceabd41dac083012103ce73e9e5cc14b9e79d6499848c509ff8333a586d382d76977336433a3730df50ffffffff98b05fc2c7efb14881b4e857f5157e81dc1f368e4dd0b214b44fbff4b1d4b7c4060000006a4730440220675694dad5d78a327e907219acdb176b97fc316b99819096c4f76affc06efd1d022009270cf2499ab267640fb8c7cbb837a64f9e79df4242e08cda08a43ef5e9510b012103aaaec8de9f04cd8fef32301dd99c6a1c85440774c0b77354c2d58e70972f23afffffffff0120a1070000000000220020cdbf909e935c855d3e8d1b61aeb9c5e3c03ae8021b286839b1a72f2e48fdba7000000000
-
-
-I60: tcls_tx2txt.sh
-===================
-an all "if Verbose=1" against v_output or vv_output
 
 
 I61: tcls_testcases for OP_RETURN
@@ -387,18 +338,6 @@ fee = (n_inputs * 148 + n_outputs * 34 + 10) * price_per_byte
 SegWit slightly changes this, where instead of paying per byte, you pay per unit of weight: 1 byte of non witness data = 4 weight, 1 byte of witness data = 1 weight. 
 
 
-67a: SegWit tx: - done
-==============
-this segwit tx is not decoded correctly, improve:
-0200000000010117017d17e296b4cd41cd63758bff8aadf214410505ccaeddb4252579ccffa40300000000171600149835f2e0dff9d7f6a4060140696bc7e00b12edd5ffffffff0100b4c404000000001976a914ac19d3fd17710e6b9a331022fe92c693fdf6659588ac024730440220452a58cf56c45edaffb952acccd2f6f2cea523cf82e73b82f8eb5e3b3b1b17c4022011de26884cf693b12f16fdd8fa6c1d96dacb97050907353852895d9b80b3fae101210206f4bad90006f70112129815b25ba585484f1bb4f8b88f8ebaec2c76f543794300000000
-t has for TXIN[0] unknown opcodes, and the last two lines could be decoded further with "VERY VERBOSE" switch?
->> WITNESS TXIN[0] stack elements: hex=02, decimal=2
->>  WITNESS[0] data length (var_int), hex=47, decimal=71, data(uchar[]):
->>   30440220452A58CF56C45EDAFFB952ACCCD2F6F2CEA523CF82E73B82F8EB5E3B3B1B17C4022011DE26884CF693B12F16FDD8FA6C1D96DACB97050907353852895D9B80B3FAE101
->>  WITNESS[1] data length (var_int), hex=21, decimal=33, data(uchar[]):
->>   0206F4BAD90006F70112129815B25BA585484F1BB4F8B88F8EBAEC2C76F5437943
- 
-
 I67b: signature for P2SH:
 ========================
 is this realized correctly in tcls_sign.sh?
@@ -411,39 +350,12 @@ is this realized correctly in tcls_sign.sh?
 https://bitcoin.stackexchange.com/questions/57848/how-to-tell-which-part-of-the-previous-tx-i-need-to-make-the-hash-to-sign-for-an/57866#57866
 
 
-I69: CSV/CLTV use case: - done
-=======================
-USECASE 1:
-you want to lock your bitcoins in the same way, as you do with a life insurance. You pay monthly a certain amount, and after "some" time, you want to grab all the bitcoins.
-USECASE 2:
-when buying bitcoins, and then selling bitcoins in less than a year, many jurisdictions impose tax payments on the gained value. So the idea is, to create a transaction, that is locked in for a year, and can easily be spend a year later. 
-
-There are three options:
-a.) nlocktime
-b.) CSV - CheckSequenceVerify (BIP68/112/113)
-c.) CLTV - CheckLocktimeVerify (BIP65)
-
-What happens in USECASE 1, when you die, and the relatives shall have access to the bitcoins?
-What happens in USECASE 2, when you have a need for some bitcoins (and for sure you want to pay the taxes for it)?
-
-Look at the files [CLTV|CSV]_decode_opcodes.txt, and implement :-)
-
-
 I70: Multisig & Segwit:
 =======================
 integrate contents of file "160905_Multisig_Segwit.txt" into tx_cl_suite
 
 
-I71: tx sequence numbers - Done
-=========================
-when sequence number != FFFFFFFF, then script throughs an error. See here:
-./tcls_tx2txt.sh -vv -T -r 0100000001671a5a1a16202bdbc338384fe62f670cea70ec283f1f2ae3b88548957d289125000000006a47304402200ee1a98c1a6ef3d0bb7293ca86fbc68c913cb69a74391ae6f6eada002c73ecfe022078381f1417b68fad15b77310a2b69ab2fabdfcfe0cec4a4bd43ca5600b04f7aa012103188faec2bf8e1589a1f96fdab1db7def26ffe193b3bc368dce14a81a390637ed000000000120c83f000000000017a914fe38c0827175580a627033a16f7009076254718d8700000000
-...
-  TX_IN[0] Sequence (uint32_t)
-*** error: expected standard sequence number (0xFFFFFFFF), found 00000000
-
-
-I72: hex values, xxd, and shell scripts
+I72: hex values, xxd, and shell scripts - done
 =======================================
 see also item 57 above ...
 


### PR DESCRIPTION
Fixed items I52, I59 and I72 of todos.txt. OpenBSD does not have xxd per default. Replaced xxd with a structure like this:
   cat myfile_with_hexchars | tr [:upper:] [:lower:] > myfile_with_hexcodes
   result=$( cat myfile_with_hexcodes | sed 's/[[:xdigit:]]\{2\}/\\x&/g' )
   printf $result > myfile_hex

This can then further be optimized to:
   printf $(sed 's/[[:xdigit:]]\{2\}/\\x&/g' < myfile_with_hexcodes) > myfile_hex

see also discussion here:
https://bitcoin.stackexchange.com/questions/55188/download-single-and-specific-block-for-study-purposes/55206?noredirect=1#comment70179_55206