### PR TITLE
I39 - Shell script pipes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -49,5 +49,5 @@ yymmmdd
                                              script "tmp_vfy.sh"
 17nov29 svn   tcls_create.sh            I26: fix msig redeemscript limits (max length, max keys)
 17dec02 svn   tcls_create.sh            I19: implement tx limit checks (max size, values, ...)
-
+17dec18 svn   all *.sh                  I39: improve shell scripts to speed up (less pipes)
 

--- a/tcls_create.sh
+++ b/tcls_create.sh
@@ -402,13 +402,16 @@ chk_bc_address_hash() {
   # checksum verification: 
   # get last 8 chars of address_hash (the reference checksum)
   # remove last 8 chars, double sha256 the string, 
-  # and the first 8 chars should match the reference checksum
-  len=${#address_hash}
   from=$(( $len - 7 ))
   chksum_l8=$( echo $address_hash | cut -b $from-$len )
   to=$(( $len - 8 ))
-  address_hash=$( echo $address_hash | cut -b 1-$to )
-  vv_output " address_hash without last 8 chars: $address_hash, chksum=$chksum_l8"
+  # echo "  len=$len, from=$from, to=$to, address_hash=$address_hash"
+  if [ $to -ne 0  ] ; then
+    address_hash=$( echo $address_hash | cut -b 1-$to )
+    vv_output " address_hash without last 8 chars: $address_hash, chksum=$chksum_l8"
+  else
+    address_hash=""
+  fi
 
   # only for P2PKH adresses, verify leading "1s" 
   # https://bitcointalk.org/index.php?topic=1026.0

--- a/tcls_key2pem.sh
+++ b/tcls_key2pem.sh
@@ -583,7 +583,7 @@ if [ $VVerbose -eq 1 ] ; then
     echo   "  the pubkey  : $pubkey"
     echo $pre_pubstr_c$pubkey > pubkey_m_hex.txt
   fi
-  printf $( cat pubkey_m_hex.txt | sed 's/[[:xdigit:]]\{2\}/\\x&/g' ) > tmp_key2pem
+  printf $( sed 's/[[:xdigit:]]\{2\}/\\x&/g' pubkey_m_hex.txt ) > tmp_key2pem
   vv_output " "
   vv_output "### base64 pubkey_m_hex.txt file and put some nice surroundings"
   vv_output "openssl enc -base64 -in tmp_key2pem"

--- a/tcls_sign.sh
+++ b/tcls_sign.sh
@@ -850,7 +850,7 @@ while [ $TX_SIG_Current -le $TX_IN_Count_dec ]
     exit 1
   fi
 
-  result=$( cat $sigtxt_tmp_fn | tr [:upper:] [:lower:] )
+  result=$( tr [:upper:] [:lower:] <$sigtxt_tmp_fn )
   if [ "$Script_Sig" != "$result" ] ; then 
     echo "# *** signature replaced after strict DER sig verification with:" >> $tmp_vfy_fn
     echo $result > $sigtxt_tmp_fn
@@ -880,7 +880,7 @@ while [ $TX_SIG_Current -le $TX_IN_Count_dec ]
   # Strict DER checking (in step 16) had it's output in file "$sigtxt_tmp_fn"
   # if multisig, need to add the "00" as two chars to the length
   # and of course we convert to hex
-  result=$( cat $sigtxt_tmp_fn | wc -c )
+  result=$( wc -c <$sigtxt_tmp_fn )
   if [ $Multisig -eq 1 ] ; then 
     result=$( echo "obase=16;($result + 2) / 2" | bc )
   else

--- a/tcls_testcases_create.sh
+++ b/tcls_testcases_create.sh
@@ -78,12 +78,12 @@ echo "================================================================" | tee -a
 
 echo "=== TESTCASE 1a: $chksum_cmd tcls_create.sh" | tee -a $logfile
 cp tcls_create.sh tmp_cfile
-chksum_ref="870796779e42461358c8dc33251f89d4259f97b0e7988d6a1c4eaca603a0bc5a" 
+chksum_ref="015442a200ddedd987eb3cc3a5d0b66d1224888b6521af26b46b0b3ee4ddee08" 
 chksum_prep
 
 echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
 cp tcls_key2pem.sh tmp_cfile
-chksum_ref="0b5fb56e663368f7e011e49b8caf3560aff87c3176c1608b482f398c1deaaf1f" 
+chksum_ref="aab5ccc4d4d9329039ea08ef13e6cbc63642e1af19c3111d95f4ac708b7040e3" 
 chksum_prep
 
 echo "=== TESTCASE 1c: $chksum_cmd tcls_verify_bc_address.awk" | tee -a $logfile
@@ -388,7 +388,7 @@ echo "./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36
 ./$create_cmd -vv -c 7423fd7c2c135958e3417bb4d192c33680bcda2c5cb8549209d36323275338f9 1 1976a9147A8911A06EF9A75A6CB6AF47D72A99A9B6ECB77988ac 117000 100000 1111111111111111111114oLvT2 | sed 's/bitcoinfees.*/bitcoinfees.21.co: LINE REPLACED BY TESTCASE SCRIPT, SEE HEADER ... ###/' > tmp_cfile
 echo "./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u" >> $logfile
 ./tcls_tx2txt.sh -vv -f tmp_c_utx.txt -u >> tmp_cfile
-chksum_ref="c8aa3b8983baada8861472209ad9a0e9ebb5e5b4f3287db4733170384da1b752" 
+chksum_ref="fca80b85df35d326ba4b4bee83cd72eabb8e6052e4ce6cdeb78056654c6cf3f5" 
 chksum_prep
 
 echo " " | tee -a $logfile
@@ -818,7 +818,7 @@ echo " TX_OUT address:  mirQLRn6ciqa3WwJSSe7RSJNVfAE9zLkS5" >> $logfile
 echo " TX_OUT amount:   50" >> $logfile
 echo "./tcls_create.sh -T -vv -c 7649b33b6d80f7b5c866fbdb413419e04223974b0a5d6a3ca54944f30474d2bf 0 4752210287f9169e265380a87cfd717ec543683f572db8b5a6d06231ff59c43429063ae4210343947d178f20b8267488e488442650c27e1e9956c824077f646d6ce13a285d8452ae 5000022000 5000000000 mirQLRn6ciqa3WwJSSe7RSJNVfAE9zLkS5" >> $logfile
 ./tcls_create.sh -T -vv -c 7649b33b6d80f7b5c866fbdb413419e04223974b0a5d6a3ca54944f30474d2bf 0 4752210287f9169e265380a87cfd717ec543683f572db8b5a6d06231ff59c43429063ae4210343947d178f20b8267488e488442650c27e1e9956c824077f646d6ce13a285d8452ae 5000022000 5000000000 mirQLRn6ciqa3WwJSSe7RSJNVfAE9zLkS5 > tmp_cfile
-chksum_ref="db47274e68ad0e13be5dae664756faf55e1aca54a7f46ca575f7627e2e1b47fe"
+chksum_ref="8a1d2d5fd3fdbe40dfc604aaa0d3cc4633221e9b72042ad979110c27d30a2b7a"
 chksum_prep
 echo " " >> $logfile
 

--- a/tcls_testcases_key2pem.sh
+++ b/tcls_testcases_key2pem.sh
@@ -85,7 +85,7 @@ echo "=============================================================" | tee -a $l
 
 echo "TESTCASE 1a: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
 cp tcls_key2pem.sh tmp_tx_cfile
-chksum_ref="0b5fb56e663368f7e011e49b8caf3560aff87c3176c1608b482f398c1deaaf1f"
+chksum_ref="aab5ccc4d4d9329039ea08ef13e6cbc63642e1af19c3111d95f4ac708b7040e3"
 chksum_prep
 
 echo "TESTCASE 1b: $chksum_cmd tcls_verify_bc_address.awk" | tee -a $logfile

--- a/tcls_testcases_sign.sh
+++ b/tcls_testcases_sign.sh
@@ -80,12 +80,12 @@ echo "================================================================" | tee -a
 
 echo "=== TESTCASE 1a: $chksum_cmd tcls_sign.sh" | tee -a $logfile
 cp tcls_sign.sh tmp_tx_cfile
-chksum_ref="eff95bc71786f6eafd5c219a04f0404f383edf1bcb3e3573b5bb7998705886ec" 
+chksum_ref="0a4ba80a16767210666463cc1fbaca03f4404a4d086a998900e4974aaadad5eb" 
 chksum_prep
 
 echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
 cp tcls_key2pem.sh tmp_tx_cfile
-chksum_ref="0b5fb56e663368f7e011e49b8caf3560aff87c3176c1608b482f398c1deaaf1f" 
+chksum_ref="aab5ccc4d4d9329039ea08ef13e6cbc63642e1af19c3111d95f4ac708b7040e3" 
 chksum_prep
 
 echo "=== TESTCASE 1c: $chksum_cmd tcls_strict_sig_verify.sh" | tee -a $logfile

--- a/tcls_testcases_tx2txt.sh
+++ b/tcls_testcases_tx2txt.sh
@@ -78,7 +78,7 @@ echo "================================================================" | tee -a
 echo "=== TESTCASE 1: checksums of all necessary files             ===" | tee -a $logfile
 echo "================================================================" | tee -a $logfile
 echo "=== TESTCASE 1a: $chksum_cmd tcls_tx2txt.sh" | tee -a $logfile
-chksum_ref="b3d71646d55401f857d7ab470a35e1ce53489bedd66283a9a8fac54f724f28bc"
+chksum_ref="1ba1838d6be0ed3eb5e2ee7d12112b210f24731ce8b14f7e84120531d34e3b56"
 cp tcls_tx2txt.sh tmpfile
 chksum_prep
  
@@ -189,7 +189,7 @@ testcase3() {
 echo "================================================================" | tee -a $logfile
 echo "=== TESTCASE 3: a fairly simple trx, 1 input, 1 output       ===" | tee -a $logfile
 echo "===  we check functionality to load data via -t parameter    ===" | tee -a $logfile
-echo "===  from https://blockchain.info ...                        ===" | tee -a $logfile
+echo "===  requires network connection (https://blockchain.info)   ===" | tee -a $logfile
 echo "================================================================" | tee -a $logfile
 echo "https://blockchain.info/de/rawtx/30375f40adcf361f5b2a5074b615ca75e5696909e8bc2f8e553c69631826fcf6" >> $logfile
 
@@ -343,11 +343,11 @@ echo " " | tee -a $logfile
 
 
 testcase9() {
-echo "=============================================================" | tee -a $logfile
-echo "=== TESTCASE 9: 4 inputs and 2 outputs (P2SH multisig!)   ===" | tee -a $logfile
-echo "===  This is a long transaction, which is fetched via     ===" >> $logfile
-echo "===  the -t parameter.                                    ===" >> $logfile
-echo "=============================================================" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
+echo "=== TESTCASE 9: 4 inputs and 2 outputs (P2SH multisig!)      ===" | tee -a $logfile
+echo "===  a long tx, which is fetched via the -t parameter.       ===" >> $logfile
+echo "===  requires network connection (https://blockchain.info)   ===" | tee -a $logfile
+echo "================================================================" | tee -a $logfile
 echo "https://blockchain.info/de/rawtx/734c48124d391bfff5750bbc39bd18e6988e8ac873c418d64d31cfdc31cc64ac" >> $logfile
 
 echo "=== TESTCASE 9a: " | tee -a $logfile

--- a/tcls_testcases_verify.sh
+++ b/tcls_testcases_verify.sh
@@ -52,12 +52,12 @@ echo "================================================================" | tee -a
 
 echo "=== TESTCASE 1a: $chksum_cmd tcls_verify_sig.sh" | tee -a $logfile
 cp tcls_verify_sig.sh tmp_tx_cfile
-chksum_ref="2d4cfa45e5de065c3ab101265d0ffa000b43e29268c486ca8f1cd6cccee9e1c0" 
+chksum_ref="da5e0fd5e6437b112d7f30ce403fe89762ae2da911cb0cbfa7929c80522767a1" 
 chksum_prep
 
 echo "=== TESTCASE 1b: $chksum_cmd tcls_key2pem.sh" | tee -a $logfile
 cp tcls_key2pem.sh tmp_tx_cfile
-chksum_ref="0b5fb56e663368f7e011e49b8caf3560aff87c3176c1608b482f398c1deaaf1f" 
+chksum_ref="aab5ccc4d4d9329039ea08ef13e6cbc63642e1af19c3111d95f4ac708b7040e3" 
 chksum_prep
 
 echo "=== TESTCASE 1c: $chksum_cmd tcls_strict_sig_verify.sh" | tee -a $logfile

--- a/tcls_tx2txt.sh
+++ b/tcls_tx2txt.sh
@@ -268,7 +268,8 @@ else
       -f)
          if [ ${#2} -gt 0 ] ; then 
            if [ -f "$2" ] ; then
-             raw_TX=$( cat $2 | sed 's/[[:xdigit:]]\{2\}/& /g' )
+             # raw_TX=$( cat $2 | sed 's/[[:xdigit:]]\{2\}/& /g' )
+             raw_TX=$( sed 's/[[:xdigit:]]\{2\}/& /g' $2 )
            else
              echo "ERROR: file not found, exiting gracefully ..."
              echo " "

--- a/tcls_verify_sig.sh
+++ b/tcls_verify_sig.sh
@@ -324,7 +324,8 @@ openssl enc -base64 -in tmp_key2pem >> pubkey.pem
 echo "-----END PUBLIC KEY-----"     >> pubkey.pem
 rm tmp_key2pem
 if [ $VVerbose -eq 1 ] ; then
-  cat pubkey.pem | sed -e 's/^/    /'
+  # cat pubkey.pem | sed -e 's/^/    /'
+  sed -e 's/^/    /' pubkey.pem 
 fi
 v_output "    openssl asn1parse pubkey"
 openssl asn1parse -in pubkey.pem > tmp_asn1parse.txt

--- a/todos.txt
+++ b/todos.txt
@@ -2,59 +2,7 @@
 ### Issues / errors in processing ###
 #####################################
 
-I19: 09Oct2016, svn: - done
-====================
-I think the maximum size of a trx is 10 kb. How many trx does that make? 
-How can this be implemented?
---> minimum signature is ~50 Bytes, prev trx = 32 Bytes + PKScript 20 Bytes plus, plus, plus... so a minimum trx is roughly 227 Bytes. This would limit to ~440 particular trx? And if a trx has many inputs and many outputs?
-
-trx validation:
-https://en.bitcoin.it/wiki/Protocol_rules#.22tx.22_messages
-    Check syntactic correctness
-    Make sure neither in or out lists are empty
-    Size in bytes <= MAX_BLOCK_SIZE (or as above, 100k max?)
-    Each output value, as well as the total, must be in legal money range
-    Make sure none of the inputs have hash=0, n=-1 (coinbase transactions)
-    Check that nLockTime <= INT_MAX[1], size in bytes >= 100[2], and sig opcount <= 2[3]
-    Reject "nonstandard" transactions: scriptSig doing anything other than pushing numbers on the stack, or scriptPubkey not matching the two usual forms[4]
-    Reject if we already have matching tx in the pool, or in a block in the main branch
-    For each input, if the referenced output exists in any other tx in the pool, reject this transaction.[5]
-    For each input, look in the main branch and the transaction pool to find the referenced output transaction. If the output transaction is missing for any input, this will be an orphan transaction. Add to the orphan transactions, if a matching transaction is not in there already.
-    For each input, if the referenced output transaction is coinbase (i.e. only 1 input, with hash=0, n=-1), it must have at least COINBASE_MATURITY (100) confirmations; else reject this transaction
-    For each input, if the referenced output does not exist (e.g. never existed or has already been spent), reject this transaction[6]
-    Using the referenced output transactions to get input values, check that each input value, as well as the sum, are in legal money range
-    Reject if the sum of input values < sum of output values
-    Reject if transaction fee (defined as sum of input values minus sum of output values) would be too low to get into an empty block
-    Verify the scriptPubKey accepts for each input; reject if any are bad
-    Add to transaction pool[7]
-    "Add to wallet if mine"
-    Relay transaction to peers
-    For each orphan transaction that uses this one as one of its inputs, run all these steps (including this one) recursively on that orphan
-
-and here from Andreas book in chapter 8:
-Each node verifies every transaction against a long checklist of criteria:
-
-    The transaction’s syntax and data structure must be correct.
-    Neither lists of inputs or outputs are empty.
-    The transaction size in bytes is less than MAX_BLOCK_SIZE.
-    Each output value, as well as the total, must be within the allowed range of values (less than 21m coins, more than 0).
-    None of the inputs have hash=0, N=–1 (coinbase transactions should not be relayed).
-    nLockTime is less than or equal to INT_MAX.
-    The transaction size in bytes is greater than or equal to 100.
-    The number of signature operations contained in the transaction is less than the signature operation limit.
-    The unlocking script (scriptSig) can only push numbers on the stack, and the locking script (scriptPubkey) must match isStandard forms (this rejects "nonstandard" transactions).
-    A matching transaction in the pool, or in a block in the main branch, must exist.
-    For each input, if the referenced output exists in any other transaction in the pool, the transaction must be rejected.
-    For each input, look in the main branch and the transaction pool to find the referenced output transaction. If the output transaction is missing for any input, this will be an orphan transaction. Add to the orphan transactions pool, if a matching transaction is not already in the pool.
-    For each input, if the referenced output transaction is a coinbase output, it must have at least COINBASE_MATURITY (100) confirmations.
-    For each input, the referenced output must exist and cannot already be spent.
-    Using the referenced output transactions to get input values, check that each input value, as well as the sum, are in the allowed range of values (less than 21m coins, more than 0).
-    Reject if the sum of input values is less than sum of output values.
-    Reject if transaction fee would be too low to get into an empty block.
-    The unlocking scripts for each input must validate against the corresponding output locking scripts.
-
-
-I39: 16nov2016, svn:
+I39: 16nov2016, svn: - done
 ====================
 Gerade in Schleifen sind immer neu gestartete Unterprozesse für jede Menge Ressourcenverbrauch verantwortlich. Ein kurzer Benchmark durchsuchte knapp 3 300 Dateien nach einem Suchstring. Die Variante in Listing 2 braucht daher 3 300 Prozesse mehr als die kürzere Variante in Listing 3. Das zweite Skript benötigte 88 Prozent mehr Laufzeit als das erste. Hängt man hinten an die Pipe ein weiteres, nutzloses »| cat« an, so dauert dies 153 Prozent länger als ein einzelnes »grep«. Zwei solche Aufrufe benötigen schon zusätzliche 239 Prozent und dreimal »cat« schlägt mit einer Zugabe von gesalzenen 322 Prozent zu Buche. Die letzteren Werte leiden überdurchschnittlich an den begrenzten Ressourcen auf dem Testrechner und lasten ihn vollständig aus. Dennoch zeigt das durchaus praxisnahe Beispiel, dass sich zusätzliche Prozesse erheblich im Schleifenrumpf auswirken.
 


### PR DESCRIPTION
remove unnecessary pipes in shell scripts, which would lead to delays. Like this:

Instead of this:
printf $( cat file.txt | sed 's/[[:xdigit:]]\{2\}/\\x&/g' ) > tmp_file

remove cat, and go like this:
printf $( sed 's/[[:xdigit:]]\{2\}/\\x&/g' file.txt ) > tmp_file